### PR TITLE
feature: implement Trackmania platform integration

### DIFF
--- a/db/migrations/001_elo_and_stats.sql
+++ b/db/migrations/001_elo_and_stats.sql
@@ -62,4 +62,19 @@ ALTER TABLE scrims ADD COLUMN IF NOT EXISTS winner_team INTEGER CHECK (winner_te
 ALTER TABLE scrims ADD COLUMN IF NOT EXISTS match_type VARCHAR(20) DEFAULT 'QUEUE' CHECK (match_type IN ('QUEUE', 'SCHEDULED'));
 ALTER TABLE scrims ADD COLUMN IF NOT EXISTS elo_processed BOOLEAN DEFAULT FALSE;
 
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'trackmania_elo_history_player_scrim_key'
+  ) THEN
+    ALTER TABLE elo_history
+      ADD CONSTRAINT trackmania_elo_history_player_scrim_key UNIQUE (player_id, scrim_id);
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_match_player_stats_unique_scrim_map_player
+  ON match_player_stats(scrim_id, COALESCE(map_id, 0), player_id);
+
 CREATE INDEX idx_scrims_elo_processed ON scrims(elo_processed);

--- a/db/migrations/003_sprocket_player_identity.sql
+++ b/db/migrations/003_sprocket_player_identity.sql
@@ -1,0 +1,86 @@
+CREATE SCHEMA IF NOT EXISTS trackmania;
+SET search_path TO trackmania, public;
+
+ALTER TABLE players
+  ADD COLUMN IF NOT EXISTS sprocket_player_id INTEGER,
+  ADD COLUMN IF NOT EXISTS member_id INTEGER,
+  ADD COLUMN IF NOT EXISTS platform_account_ids VARCHAR[] DEFAULT ARRAY[]::VARCHAR[];
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_players_sprocket_player_id
+  ON players(sprocket_player_id)
+  WHERE sprocket_player_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_players_member_id
+  ON players(member_id)
+  WHERE member_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_players_platform_account_ids
+  ON players USING GIN(platform_account_ids);
+
+UPDATE players lp
+SET sprocket_player_id = profile.sprocket_player_id,
+    member_id = profile.member_id,
+    platform_account_ids = profile.platform_accounts,
+    updated_at = NOW()
+FROM (
+  SELECT
+    p.id AS sprocket_player_id,
+    m.id AS member_id,
+    uaa."accountId" AS discord_id,
+    COALESCE(
+      ARRAY_AGG(DISTINCT mpa."platformAccountId")
+      FILTER (WHERE mpa."platformAccountId" IS NOT NULL),
+      ARRAY[]::VARCHAR[]
+    ) AS platform_accounts
+  FROM sprocket.user_authentication_account uaa
+  JOIN sprocket."user" u ON u.id = uaa."userId"
+  JOIN sprocket.member m ON m."userId" = u.id
+  JOIN sprocket.player p ON p."memberId" = m.id
+  JOIN sprocket.game_skill_group gsg ON gsg.id = p."skillGroupId"
+  JOIN sprocket.game g ON g.id = gsg."gameId"
+  LEFT JOIN sprocket.member_platform_account mpa ON mpa."memberId" = m.id
+  WHERE uaa."accountType" = 'DISCORD'
+    AND g.title = 'Trackmania'
+  GROUP BY p.id, m.id, uaa."accountId"
+) profile
+WHERE lp.discord_id = profile.discord_id;
+
+DO $$
+DECLARE
+  duplicate_discord_ids TEXT;
+  duplicate_sprocket_ids TEXT;
+BEGIN
+  SELECT STRING_AGG(discord_id, ', ')
+  INTO duplicate_discord_ids
+  FROM (
+    SELECT uaa."accountId" AS discord_id
+    FROM sprocket.user_authentication_account uaa
+    JOIN sprocket."user" u ON u.id = uaa."userId"
+    JOIN sprocket.member m ON m."userId" = u.id
+    JOIN sprocket.player p ON p."memberId" = m.id
+    JOIN sprocket.game_skill_group gsg ON gsg.id = p."skillGroupId"
+    JOIN sprocket.game g ON g.id = gsg."gameId"
+    WHERE uaa."accountType" = 'DISCORD'
+      AND g.title = 'Trackmania'
+    GROUP BY uaa."accountId"
+    HAVING COUNT(DISTINCT p.id) > 1
+  ) duplicates;
+
+  IF duplicate_discord_ids IS NOT NULL THEN
+    RAISE WARNING 'Duplicate Trackmania Sprocket profiles found for Discord IDs: %', duplicate_discord_ids;
+  END IF;
+
+  SELECT STRING_AGG(sprocket_player_id::TEXT, ', ')
+  INTO duplicate_sprocket_ids
+  FROM (
+    SELECT sprocket_player_id
+    FROM trackmania.players
+    WHERE sprocket_player_id IS NOT NULL
+    GROUP BY sprocket_player_id
+    HAVING COUNT(*) > 1
+  ) duplicates;
+
+  IF duplicate_sprocket_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'Duplicate sprocket_player_id values after backfill: %', duplicate_sprocket_ids;
+  END IF;
+END $$;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -9,12 +9,18 @@ CREATE TABLE IF NOT EXISTS players (
   discord_id VARCHAR(20) UNIQUE NOT NULL,
   discord_username VARCHAR(255) NOT NULL,
   league VARCHAR(50) NOT NULL CHECK (league IN ('Academy', 'Champion', 'Master')),
+  sprocket_player_id INTEGER UNIQUE,
+  member_id INTEGER,
+  platform_account_ids VARCHAR[] DEFAULT ARRAY[]::VARCHAR[],
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW()
 );
 
 CREATE INDEX idx_players_discord_id ON players(discord_id);
 CREATE INDEX idx_players_league ON players(league);
+CREATE INDEX idx_players_sprocket_player_id ON players(sprocket_player_id) WHERE sprocket_player_id IS NOT NULL;
+CREATE INDEX idx_players_member_id ON players(member_id) WHERE member_id IS NOT NULL;
+CREATE INDEX idx_players_platform_account_ids ON players USING GIN(platform_account_ids);
 
 -- Queue bans table
 CREATE TABLE IF NOT EXISTS queue_bans (

--- a/parser/Code.js
+++ b/parser/Code.js
@@ -1046,6 +1046,17 @@ function verifyReplay(data) {
       const rowNum = i + 1;
       const mapEntry = tempValues[i];
 
+      // Ensure verifier is acting on the intended scrim from the submission URL.
+      var submittedScrimUid = String(mapEntry[10] || '').trim();
+      if (!submittedScrimUid) {
+        return { success: false, message: "❌ Submission is missing its Scrim UID." };
+      }
+
+      var intendedScrim = Repository.getScrimByUid(submittedScrimUid);
+      if (!intendedScrim || Number(intendedScrim.id) !== Number(data.scrimId)) {
+        return { success: false, message: "❌ Replay does not match the intended scrim." };
+      }
+
       // 1. Update Temp Submissions verification status
       tempSheet.getRange(rowNum, 7).setValue(data.verifiedBy); // G: Verified By
       tempSheet.getRange(rowNum, 8).setValue("✅ Verified"); // H: Verified
@@ -1063,19 +1074,33 @@ function verifyReplay(data) {
       // *** Parse ALL maps from the JSON data ***
       const allParsedMaps = ParseAllReplayMaps(jsonData);
 
-      // --- Loop over all maps to save to DB ---
-      for (const parsed of allParsedMaps) {
-        if (!parsed) continue;
+      var cumulativeScores = { 1: 0, 2: 0 };
+      allParsedMaps.forEach(function (parsed) {
+        var mapScores = calculateMapScores(parsed.driverPlacements);
+        mapScores.forEach(function (score) {
+          var teamNumber = parseInt(score.teamName);
+          if (teamNumber === 1 || teamNumber === 2) {
+            cumulativeScores[teamNumber] += score.totalPoints;
+          }
+        });
+      });
 
-        const mapScores = calculateMapScores(parsed.driverPlacements);
-        const winningTeamNumber = mapScores[0].teamName; // "1" or "2"
+      if (cumulativeScores[1] === cumulativeScores[2]) {
+        return { success: false, message: "❌ Cannot verify a tied cumulative match score." };
+      }
 
-        // Save to Database
-        Repository.saveMatchResults(
-          data.scrimId,
-          parsed,
-          parseInt(winningTeamNumber)
-        );
+      var winningTeamNumber = cumulativeScores[1] > cumulativeScores[2] ? 1 : 2;
+      var saveResult = Repository.saveMatchResults(
+        data.scrimId,
+        allParsedMaps,
+        winningTeamNumber
+      );
+
+      if (saveResult.alreadyProcessed) {
+        return {
+          success: true,
+          message: "Match was already completed and Elo processed; no duplicate rows were written.",
+        };
       }
 
       Repository.awardEligibilityPoints(data.scrimId, 3);
@@ -1089,7 +1114,7 @@ function verifyReplay(data) {
 
       return {
         success: true,
-        message: `✅ Verification successful! Data for ${allParsedMaps.length} map(s) saved to database.`,
+        message: `Verification successful! Data for ${allParsedMaps.length} map(s) saved to database. Match winner: Team ${winningTeamNumber}.`,
         mapName: loggedMap.mapName,
       };
     }

--- a/parser/Repository.js
+++ b/parser/Repository.js
@@ -6,42 +6,57 @@ var Repository = (function () {
   var SPROCKET_SCHEMA = "sprocket";
   var ELIGIBILITY_POINTS = 3;
 
-  function findTrackmaniaPlayerId(conn, platformAccountId, fallbackDiscordUsername) {
+  function findTrackmaniaPlayer(conn, platformAccountId, fallbackDiscordUsername) {
     if (platformAccountId !== null && platformAccountId !== undefined && String(platformAccountId).trim() !== "") {
       var stmt = conn.prepareStatement(
-        "SELECT lp.id " +
+        "SELECT lp.id, lp.sprocket_player_id " +
           'FROM "' + APP_SCHEMA + '".players lp ' +
-          'JOIN "' + SPROCKET_SCHEMA + '".user_authentication_account uaa ' +
-          '  ON uaa."accountId" = lp.discord_id ' +
-          ' AND uaa."accountType" = \'DISCORD\' ' +
-          'JOIN "' + SPROCKET_SCHEMA + '".user u ON u.id = uaa."userId" ' +
-          'JOIN "' + SPROCKET_SCHEMA + '".member m ON m."userId" = u.id ' +
-          'JOIN "' + SPROCKET_SCHEMA + '".member_platform_account mpa ON mpa."memberId" = m.id ' +
-          'JOIN "' + SPROCKET_SCHEMA + '".player sp ON sp."memberId" = m.id ' +
+          'JOIN "' + SPROCKET_SCHEMA + '".member_platform_account mpa ' +
+          '  ON mpa."platformAccountId" = ? ' +
+          'JOIN "' + SPROCKET_SCHEMA + '".player sp ' +
+          '  ON sp.id = lp.sprocket_player_id ' +
+          ' AND sp."memberId" = mpa."memberId" ' +
           'JOIN "' + SPROCKET_SCHEMA + '".game_skill_group gsg ON gsg.id = sp."skillGroupId" ' +
           'JOIN "' + SPROCKET_SCHEMA + '".game g ON g.id = gsg."gameId" ' +
-          'WHERE mpa."platformAccountId" = ? ' +
-          "  AND g.title = 'Trackmania' " +
-          "LIMIT 1"
+          "WHERE g.title = 'Trackmania' " +
+          "LIMIT 2"
       );
       stmt.setString(1, String(platformAccountId));
       var rs = stmt.executeQuery();
-      var playerId = rs.next() ? rs.getInt("id") : null;
+      var matches = [];
+      while (rs.next()) {
+        matches.push({
+          localPlayerId: rs.getInt("id"),
+          sprocketPlayerId: rs.getInt("sprocket_player_id"),
+        });
+      }
       rs.close();
       stmt.close();
-      if (playerId) return playerId;
+      if (matches.length === 1) return matches[0];
+      if (matches.length > 1) {
+        throw new Error("Multiple Trackmania players resolved for platform account " + platformAccountId);
+      }
     }
 
     if (fallbackDiscordUsername && String(fallbackDiscordUsername).trim() !== "") {
       var fallbackStmt = conn.prepareStatement(
-        'SELECT id FROM "' + APP_SCHEMA + '".players WHERE discord_username = ? LIMIT 1'
+        'SELECT id, sprocket_player_id FROM "' + APP_SCHEMA + '".players WHERE discord_username = ? LIMIT 2'
       );
       fallbackStmt.setString(1, String(fallbackDiscordUsername));
       var fallbackRs = fallbackStmt.executeQuery();
-      var fallbackPlayerId = fallbackRs.next() ? fallbackRs.getInt("id") : null;
+      var fallbackMatches = [];
+      while (fallbackRs.next()) {
+        fallbackMatches.push({
+          localPlayerId: fallbackRs.getInt("id"),
+          sprocketPlayerId: fallbackRs.getInt("sprocket_player_id"),
+        });
+      }
       fallbackRs.close();
       fallbackStmt.close();
-      return fallbackPlayerId;
+      if (fallbackMatches.length === 1) return fallbackMatches[0];
+      if (fallbackMatches.length > 1) {
+        throw new Error("Multiple Trackmania players resolved for replay name " + fallbackDiscordUsername);
+      }
     }
 
     return null;
@@ -113,8 +128,8 @@ var Repository = (function () {
       var unresolvedDrivers = [];
 
       parsedMap.driverPlacements.forEach(function (driver) {
-        var playerId = findTrackmaniaPlayerId(conn, driver.id, driver.name);
-        if (!playerId) {
+        var player = findTrackmaniaPlayer(conn, driver.id, driver.name);
+        if (!player || !player.localPlayerId || !player.sprocketPlayerId) {
           unresolvedDrivers.push(
             (driver.name || "Unknown") +
               (driver.id ? " [" + driver.id + "]" : "")
@@ -124,7 +139,7 @@ var Repository = (function () {
 
         insertStats.setInt(1, scrimId);
         insertStats.setString(2, parsedMap.mapId || "");
-        insertStats.setInt(3, playerId);
+        insertStats.setInt(3, player.localPlayerId);
         insertStats.setInt(4, parseInt(driver.team));
         insertStats.setInt(5, driver.points);
         insertStats.setBoolean(6, driver.status === "Finished");
@@ -185,19 +200,25 @@ var Repository = (function () {
       }
 
       var playerStmt = conn.prepareStatement(
-        'SELECT DISTINCT player_id FROM "' +
+        'SELECT DISTINCT p.sprocket_player_id FROM "' +
           APP_SCHEMA +
-          '".scrim_players WHERE scrim_id = ?'
+          '".scrim_players sp ' +
+          'JOIN "' + APP_SCHEMA + '".players p ON p.id = sp.player_id ' +
+          'WHERE sp.scrim_id = ? AND p.sprocket_player_id IS NOT NULL'
       );
       playerStmt.setInt(1, scrimId);
       var playerRs = playerStmt.executeQuery();
 
       var playerIds = [];
       while (playerRs.next()) {
-        playerIds.push(playerRs.getInt("player_id"));
+        playerIds.push(playerRs.getInt("sprocket_player_id"));
       }
       playerRs.close();
       playerStmt.close();
+
+      if (playerIds.length === 0) {
+        throw new Error("No Sprocket player IDs found for scrim eligibility award.");
+      }
 
       var upsertStmt = conn.prepareStatement(
         'INSERT INTO "' +

--- a/parser/Repository.js
+++ b/parser/Repository.js
@@ -99,59 +99,88 @@ var Repository = (function () {
    * @param {Object} parsedMap - The parsed map data
    * @param {number} winnerTeam - 1 or 2
    */
-  function saveMatchResults(scrimId, parsedMap, winnerTeam) {
+  function saveMatchResults(scrimId, parsedMaps, winnerTeam) {
     var conn = Database.getConnection();
     conn.setAutoCommit(false);
 
     try {
-      // 1. Update Scrim Status
+      var mapsToSave = Array.isArray(parsedMaps) ? parsedMaps : [parsedMaps];
+
+      var scrimCheck = conn.prepareStatement(
+        'SELECT status, elo_processed FROM "' + APP_SCHEMA + '".scrims WHERE id = ? FOR UPDATE'
+      );
+      scrimCheck.setInt(1, scrimId);
+      var scrimRs = scrimCheck.executeQuery();
+      if (!scrimRs.next()) {
+        throw new Error("Scrim not found for verification.");
+      }
+      var currentStatus = scrimRs.getString("status");
+      var eloProcessed = scrimRs.getBoolean("elo_processed");
+      scrimRs.close();
+      scrimCheck.close();
+
+      if (currentStatus === "completed" && eloProcessed) {
+        conn.rollback();
+        return { alreadyProcessed: true, insertedStats: 0 };
+      }
+
+      // 1. Update Scrim Status once using cumulative match winner
       var updateScrim = conn.prepareStatement(
         'UPDATE "' +
           APP_SCHEMA +
-          "\".scrims SET status = 'completed', completed_at = NOW(), winner_team = ? WHERE id = ?"
+          '".scrims SET status = \'completed\', completed_at = COALESCE(completed_at, NOW()), winner_team = ? WHERE id = ?'
       );
       updateScrim.setInt(1, winnerTeam);
       updateScrim.setInt(2, scrimId);
       updateScrim.executeUpdate();
+      updateScrim.close();
 
-      // 2. Insert Match Player Stats
+      // 2. Insert Match Player Stats idempotently
       var insertStats = conn.prepareStatement(
         'INSERT INTO "' +
           APP_SCHEMA +
           '".match_player_stats ' +
-          "(scrim_id, map_id, player_id, team_id, points, is_finished, is_dnf, nb_respawns, best_time) " +
+          "(scrim_id, map_id, player_id, team_id, points, is_finished, is_dnf, round_points, nb_respawns, respawn_times, best_time, cp_times, respawn_time_loss, nb_respawns_by_cp) " +
           'VALUES (?, (SELECT id FROM "' +
           APP_SCHEMA +
-          '".maps WHERE uid = ? LIMIT 1), ?, ?, ?, ?, ?, ?, ?)'
+          '".maps WHERE uid = ? LIMIT 1), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ' +
+          'ON CONFLICT (scrim_id, COALESCE(map_id, 0), player_id) DO NOTHING'
       );
 
       var unresolvedDrivers = [];
+      var insertedStats = 0;
 
-      parsedMap.driverPlacements.forEach(function (driver) {
-        var player = findTrackmaniaPlayer(conn, driver.id, driver.name);
-        if (!player || !player.localPlayerId || !player.sprocketPlayerId) {
-          unresolvedDrivers.push(
-            (driver.name || "Unknown") +
-              (driver.id ? " [" + driver.id + "]" : "")
-          );
-          return;
-        }
+      mapsToSave.forEach(function (parsedMap) {
+        parsedMap.driverPlacements.forEach(function (driver) {
+          var player = findTrackmaniaPlayer(conn, driver.id, driver.name);
+          if (!player || !player.localPlayerId || !player.sprocketPlayerId) {
+            unresolvedDrivers.push(
+              (driver.name || "Unknown") +
+                (driver.id ? " [" + driver.id + "]" : "")
+            );
+            return;
+          }
 
-        insertStats.setInt(1, scrimId);
-        insertStats.setString(2, parsedMap.mapId || "");
-        insertStats.setInt(3, player.localPlayerId);
-        insertStats.setInt(4, parseInt(driver.team));
-        insertStats.setInt(5, driver.points);
-        insertStats.setBoolean(6, driver.status === "Finished");
-        insertStats.setBoolean(7, driver.status === "DNF");
-        insertStats.setInt(8, driver.nbRespawns);
+          insertStats.setInt(1, scrimId);
+          insertStats.setString(2, parsedMap.mapId || "");
+          insertStats.setInt(3, player.localPlayerId);
+          insertStats.setInt(4, parseInt(driver.team));
+          insertStats.setInt(5, driver.points);
+          insertStats.setBoolean(6, driver.status === "Finished");
+          insertStats.setBoolean(7, driver.status === "DNF");
+          insertStats.setArray(8, conn.createArrayOf("integer", driver.roundPoints || []));
+          insertStats.setInt(9, driver.nbRespawns || 0);
+          insertStats.setArray(10, conn.createArrayOf("integer", driver.respawnTimes || []));
 
-        // Handle bestTime (might be string or number)
-        var bestTime =
-          typeof driver.bestTime === "number" ? driver.bestTime : 0;
-        insertStats.setInt(9, bestTime);
+          var bestTime = typeof driver.bestTime === "number" ? driver.bestTime : 0;
+          insertStats.setInt(11, bestTime);
+          insertStats.setArray(12, conn.createArrayOf("integer", driver.cpTimes || []));
+          insertStats.setArray(13, conn.createArrayOf("integer", driver.respawnTimeLoss || []));
+          insertStats.setArray(14, conn.createArrayOf("integer", [driver.nbRespawnsByCP || 0]));
 
-        insertStats.addBatch();
+          insertStats.addBatch();
+          insertedStats++;
+        });
       });
 
       if (unresolvedDrivers.length > 0) {
@@ -162,9 +191,10 @@ var Repository = (function () {
       }
 
       insertStats.executeBatch();
+      insertStats.close();
 
       conn.commit();
-      return true;
+      return { alreadyProcessed: false, insertedStats: insertedStats };
     } catch (e) {
       conn.rollback();
       Logger.log("Error saving match results: " + e.message);

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -11,6 +11,7 @@ import { scrimService } from '../services/scrim.service.js';
 import { eloService } from '../services/elo.service.js';
 import { matchAuditService, MatchAuditReport } from '../services/match-audit.service.js';
 import { rosterService } from '../services/roster.service.js';
+import { identityBackfillService } from '../services/identity-backfill.service.js';
 import { logger } from '../utils/logger.js';
 import { League } from '../types.js';
 
@@ -161,6 +162,11 @@ export const data = new SlashCommandBuilder()
             { name: 'Master', value: 'Master' }
           )
       )
+  )
+  .addSubcommand(subcommand =>
+    subcommand
+      .setName('backfill-identities')
+      .setDescription('Backfill local Trackmania players with Sprocket identity fields')
   )
   .addSubcommand(subcommand =>
     subcommand
@@ -317,6 +323,9 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             break;
           case 'elo':
             await handleElo(interaction);
+            break;
+          case 'backfill-identities':
+            await handleBackfillIdentities(interaction);
             break;
           case 'cancel-scrim':
             await handleCancelScrim(interaction);
@@ -555,7 +564,7 @@ async function handleRosterCommand(
         .setTitle(`Roster: ${franchise} - ${league}`)
         .setDescription(
           rows.length > 0
-            ? rows.map((row) => `${row.role_name}: ${row.discord_id ? `<@${row.discord_id}>` : 'Empty'} (slot ${row.slot_id})`).join('\n')
+            ? rows.map((row) => `${row.role_name}: ${formatRosterDisplayName(row)} (slot ${row.slot_id})`).join('\n')
             : 'No roster slots found.'
         )
         .setTimestamp();
@@ -927,6 +936,49 @@ function buildAuditEmbed(report: MatchAuditReport) {
   });
 
   return embed.setTimestamp();
+}
+
+async function handleBackfillIdentities(interaction: ChatInputCommandInteraction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const issues = await identityBackfillService.backfillTrackmaniaPlayerIdentities();
+  const missing = issues.filter((issue) => issue.reason === 'missing_sprocket_profile');
+  const duplicates = issues.filter((issue) => issue.reason === 'duplicate_sprocket_profiles');
+
+  const embed = new EmbedBuilder()
+    .setColor(issues.length === 0 ? 0x00aa55 : 0xff9900)
+    .setTitle('Trackmania Identity Backfill')
+    .setDescription(
+      issues.length === 0
+        ? 'Backfill completed successfully. No missing or duplicate Sprocket profiles were found.'
+        : `Backfill completed with ${issues.length} issue(s). Missing: ${missing.length}. Duplicates: ${duplicates.length}.`
+    )
+    .setTimestamp();
+
+  if (issues.length > 0) {
+    embed.addFields({
+      name: 'Issues',
+      value: issues
+        .slice(0, 10)
+        .map((issue) => {
+          const profileIds = issue.sprocket_player_ids.length > 0 ? issue.sprocket_player_ids.join(', ') : 'none';
+          return `${issue.discord_username} (${issue.discord_id}) local ${issue.local_player_id}: ${issue.reason}; Sprocket profiles: ${profileIds}`;
+        })
+        .join('\n')
+        .slice(0, 1024),
+      inline: false,
+    });
+  }
+
+  await interaction.editReply({ embeds: [embed] });
+}
+
+function formatRosterDisplayName(row: { discord_id: string | null; discord_username?: string | null; player_id: number | null }) {
+  if (!row.player_id) {
+    return 'Empty';
+  }
+
+  return row.discord_username || row.discord_id || `Sprocket player ${row.player_id}`;
 }
 
 async function handleCancelScrim(interaction: ChatInputCommandInteraction) {

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -9,6 +9,8 @@ import { banService } from '../services/ban.service.js';
 import { playerService } from '../services/player.service.js';
 import { scrimService } from '../services/scrim.service.js';
 import { eloService } from '../services/elo.service.js';
+import { matchAuditService, MatchAuditReport } from '../services/match-audit.service.js';
+import { rosterService } from '../services/roster.service.js';
 import { logger } from '../utils/logger.js';
 import { League } from '../types.js';
 
@@ -106,10 +108,15 @@ export const data = new SlashCommandBuilder()
             { name: 'Master', value: 'Master' }
           )
       )
-      .addUserOption(option => option.setName('p1').setDescription('Player 1').setRequired(true))
-      .addUserOption(option => option.setName('p2').setDescription('Player 2').setRequired(true))
-      .addUserOption(option => option.setName('p3').setDescription('Player 3').setRequired(true))
-      .addUserOption(option => option.setName('p4').setDescription('Player 4').setRequired(true))
+      .addUserOption(option => option.setName('p1').setDescription('Home player 1').setRequired(true))
+      .addUserOption(option => option.setName('p2').setDescription('Home player 2').setRequired(true))
+      .addUserOption(option => option.setName('p3').setDescription('Away player 1').setRequired(true))
+      .addUserOption(option => option.setName('p4').setDescription('Away player 2').setRequired(true))
+      .addIntegerOption(option => option.setName('fixture_id').setDescription('Existing Sprocket fixture ID').setRequired(false))
+      .addStringOption(option => option.setName('home_franchise').setDescription('Home franchise name/code for a test fixture').setRequired(false))
+      .addStringOption(option => option.setName('away_franchise').setDescription('Away franchise name/code for a test fixture').setRequired(false))
+      .addIntegerOption(option => option.setName('schedule_group_id').setDescription('Optional Sprocket schedule group ID').setRequired(false))
+      .addIntegerOption(option => option.setName('week').setDescription('Optional week for Trackmania Test schedule group').setRequired(false))
   )
   .addSubcommand(subcommand =>
     subcommand
@@ -124,6 +131,39 @@ export const data = new SlashCommandBuilder()
   )
   .addSubcommand(subcommand =>
     subcommand
+      .setName('audit-match')
+      .setDescription('Audit a Trackmania scrim result and Sprocket linkage')
+      .addStringOption(option =>
+        option
+          .setName('scrim_id')
+          .setDescription('The Scrim ID (UUID) to audit')
+          .setRequired(true)
+      )
+  )
+  .addSubcommand(subcommand =>
+    subcommand
+      .setName('elo')
+      .setDescription('Inspect current Elo and recent Elo history for a player')
+      .addUserOption(option =>
+        option
+          .setName('player')
+          .setDescription('The player to inspect')
+          .setRequired(true)
+      )
+      .addStringOption(option =>
+        option
+          .setName('league')
+          .setDescription('Optional league filter')
+          .setRequired(false)
+          .addChoices(
+            { name: 'Academy', value: 'Academy' },
+            { name: 'Champion', value: 'Champion' },
+            { name: 'Master', value: 'Master' }
+          )
+      )
+  )
+  .addSubcommand(subcommand =>
+    subcommand
       .setName('cancel-scrim')
       .setDescription('Cancel a queue scrim and return eligible players to the queue')
       .addStringOption(option =>
@@ -131,6 +171,53 @@ export const data = new SlashCommandBuilder()
           .setName('scrim_id')
           .setDescription('The Scrim ID (UUID) to cancel')
           .setRequired(true)
+      )
+  )
+  .addSubcommandGroup(group =>
+    group
+      .setName('roster')
+      .setDescription('Manage Trackmania Sprocket rosters')
+      .addSubcommand(subcommand =>
+        subcommand
+          .setName('add')
+          .setDescription('Add or move a player to a roster slot')
+          .addUserOption(option => option.setName('player').setDescription('Player to add').setRequired(true))
+          .addStringOption(option => option.setName('franchise').setDescription('Franchise name/code').setRequired(true))
+          .addStringOption(option => option.setName('slot').setDescription('Roster slot/role').setRequired(true))
+          .addStringOption(option =>
+            option
+              .setName('league')
+              .setDescription('League')
+              .setRequired(true)
+              .addChoices(
+                { name: 'Academy', value: 'Academy' },
+                { name: 'Champion', value: 'Champion' },
+                { name: 'Master', value: 'Master' }
+              )
+          )
+      )
+      .addSubcommand(subcommand =>
+        subcommand
+          .setName('remove')
+          .setDescription('Remove a player from any Trackmania roster slot')
+          .addUserOption(option => option.setName('player').setDescription('Player to remove').setRequired(true))
+      )
+      .addSubcommand(subcommand =>
+        subcommand
+          .setName('show')
+          .setDescription('Show a franchise roster')
+          .addStringOption(option => option.setName('franchise').setDescription('Franchise name/code').setRequired(true))
+          .addStringOption(option =>
+            option
+              .setName('league')
+              .setDescription('League')
+              .setRequired(true)
+              .addChoices(
+                { name: 'Academy', value: 'Academy' },
+                { name: 'Champion', value: 'Champion' },
+                { name: 'Master', value: 'Master' }
+              )
+          )
       )
   )
   .addSubcommandGroup(group =>
@@ -196,6 +283,9 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
   try {
     switch (subcommandGroup) {
+      case 'roster':
+        await handleRosterCommand(interaction, subcommand);
+        break;
       case 'state':
         await handleStateCommand(interaction, subcommand);
         break;
@@ -221,6 +311,12 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             break;
           case 'calc-elo':
             await handleCalcElo(interaction);
+            break;
+          case 'audit-match':
+            await handleAuditMatch(interaction);
+            break;
+          case 'elo':
+            await handleElo(interaction);
             break;
           case 'cancel-scrim':
             await handleCancelScrim(interaction);
@@ -426,6 +522,51 @@ async function handleDodges(interaction: ChatInputCommandInteraction) {
   await interaction.reply({ embeds: [embed], ephemeral: true });
 }
 
+async function handleRosterCommand(
+  interaction: ChatInputCommandInteraction,
+  subcommand: string
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  switch (subcommand) {
+    case 'add': {
+      const user = interaction.options.getUser('player', true);
+      const franchise = interaction.options.getString('franchise', true);
+      const slot = interaction.options.getString('slot', true);
+      const league = interaction.options.getString('league', true) as League;
+      const row = await rosterService.addPlayer(user.id, franchise, slot, league);
+      await interaction.editReply({
+        content: `Added <@${user.id}> to ${row.franchise_name} ${league} slot ${row.role_name}.`,
+      });
+      return;
+    }
+    case 'remove': {
+      const user = interaction.options.getUser('player', true);
+      const cleared = await rosterService.removePlayer(user.id);
+      await interaction.editReply({ content: `Removed <@${user.id}> from ${cleared} roster slot(s).` });
+      return;
+    }
+    case 'show': {
+      const franchise = interaction.options.getString('franchise', true);
+      const league = interaction.options.getString('league', true) as League;
+      const rows = await rosterService.showFranchise(franchise, league);
+      const embed = new EmbedBuilder()
+        .setColor(0x00aa55)
+        .setTitle(`Roster: ${franchise} - ${league}`)
+        .setDescription(
+          rows.length > 0
+            ? rows.map((row) => `${row.role_name}: ${row.discord_id ? `<@${row.discord_id}>` : 'Empty'} (slot ${row.slot_id})`).join('\n')
+            : 'No roster slots found.'
+        )
+        .setTimestamp();
+      await interaction.editReply({ embeds: [embed] });
+      return;
+    }
+    default:
+      await interaction.editReply({ content: 'Unknown roster subcommand.' });
+  }
+}
+
 async function handleStateCommand(
   interaction: ChatInputCommandInteraction,
   subcommand: string
@@ -578,6 +719,12 @@ async function handleCreateMatch(interaction: ChatInputCommandInteraction) {
   const p3 = interaction.options.getUser('p3', true);
   const p4 = interaction.options.getUser('p4', true);
 
+  const fixtureId = interaction.options.getInteger('fixture_id') ?? undefined;
+  const homeFranchise = interaction.options.getString('home_franchise') ?? undefined;
+  const awayFranchise = interaction.options.getString('away_franchise') ?? undefined;
+  const scheduleGroupId = interaction.options.getInteger('schedule_group_id') ?? undefined;
+  const week = interaction.options.getInteger('week') ?? undefined;
+
   const discordIds = [p1.id, p2.id, p3.id, p4.id];
 
   // Ensure all players are registered
@@ -595,10 +742,16 @@ async function handleCreateMatch(interaction: ChatInputCommandInteraction) {
   }
 
   try {
-    const scrim = await scrimService.createScheduledMatch(league, players);
+    const scrim = await scrimService.createScheduledMatch(league, players, {
+      fixtureId,
+      homeFranchise,
+      awayFranchise,
+      scheduleGroupId,
+      week,
+    });
 
     await interaction.reply({
-      content: `✅ Scheduled Match Created!\nID: \`${scrim.scrim_uid}\`\nLeague: ${league}\nPlayers: ${players.map(p => p.discord_username).join(', ')}`,
+      content: `Scheduled Match Created!\nID: \`${scrim.scrim_uid}\`\nLeague: ${league}\nFixture: ${fixtureId ?? (homeFranchise && awayFranchise ? `${homeFranchise} vs ${awayFranchise}` : 'none')}\nPlayers: ${players.map(p => p.discord_username).join(', ')}`,
       ephemeral: false
     });
   } catch (error) {
@@ -662,6 +815,118 @@ async function handleCalcElo(interaction: ChatInputCommandInteraction) {
       });
     }
   }
+}
+
+async function handleAuditMatch(interaction: ChatInputCommandInteraction) {
+  const scrimUid = interaction.options.getString('scrim_id', true);
+  await interaction.deferReply({ ephemeral: true });
+
+  const report = await matchAuditService.auditByScrimUid(scrimUid);
+  if (!report) {
+    await interaction.editReply({ content: `Scrim \`${scrimUid}\` was not found.` });
+    return;
+  }
+
+  await interaction.editReply({ embeds: [buildAuditEmbed(report)] });
+}
+
+async function handleElo(interaction: ChatInputCommandInteraction) {
+  const user = interaction.options.getUser('player', true);
+  const league = interaction.options.getString('league') as League | null;
+  await interaction.deferReply({ ephemeral: true });
+
+  const player = await playerService.getByDiscordId(user.id);
+  if (!player) {
+    await interaction.editReply({ content: `${user.username} is not registered in the system.` });
+    return;
+  }
+
+  const summary = await eloService.getPlayerEloSummary(player.id, league ?? undefined);
+  const embed = new EmbedBuilder()
+    .setColor(0x3366cc)
+    .setTitle(`Elo: ${player.discord_username}`)
+    .setDescription(`Local player ${player.id} | Sprocket ${player.sprocket_player_id ?? 'n/a'}`);
+
+  embed.addFields({
+    name: 'Current Ratings',
+    value:
+      summary.ratings.length > 0
+        ? summary.ratings
+            .map((rating) => `${rating.league}: ${rating.rating} (${rating.wins}W/${rating.losses}L)`)
+            .join('\n')
+        : 'No current ratings found.',
+    inline: false,
+  });
+
+  embed.addFields({
+    name: 'Recent History',
+    value:
+      summary.history.length > 0
+        ? summary.history
+            .slice(0, 10)
+            .map((row) => `${row.scrim_uid}: ${row.old_rating} → ${row.new_rating} (${row.change_amount >= 0 ? '+' : ''}${row.change_amount})`)
+            .join('\n')
+        : 'No Elo history found.',
+    inline: false,
+  });
+
+  await interaction.editReply({ embeds: [embed.setTimestamp()] });
+}
+
+function buildAuditEmbed(report: MatchAuditReport) {
+  const passFail = (passed: boolean) => (passed ? 'PASS' : 'FAIL');
+  const embed = new EmbedBuilder()
+    .setColor(Object.values(report.checks).every(Boolean) ? 0x00aa55 : 0xff9900)
+    .setTitle(`Match Audit: ${report.scrim.scrim_uid}`)
+    .setDescription(
+      [
+        `Local ID: ${report.scrim.id}`,
+        `Status: ${report.scrim.match_type} / ${report.scrim.status}`,
+        `Sprocket: parent ${report.scrim.sprocket_match_parent_id ?? 'n/a'} | match ${report.scrim.sprocket_match_id ?? 'n/a'}`,
+        `Winner Team: ${report.scrim.winner_team ?? 'n/a'} | Elo Processed: ${report.scrim.elo_processed ? 'yes' : 'no'}`,
+      ].join('\n')
+    );
+
+  embed.addFields({
+    name: 'Checks',
+    value: Object.entries(report.checks)
+      .map(([name, passed]) => `${name}: ${passFail(passed)}`)
+      .join('\n'),
+    inline: false,
+  });
+
+  embed.addFields({
+    name: 'Fixture',
+    value: report.fixture
+      ? [
+          `Fixture: ${report.fixture.fixture_id}`,
+          `Home: ${report.fixture.home_franchise_name ?? report.fixture.home_franchise_id ?? 'n/a'}`,
+          `Away: ${report.fixture.away_franchise_name ?? report.fixture.away_franchise_id ?? 'n/a'}`,
+          `Group: ${report.fixture.schedule_group_name ?? report.fixture.schedule_group_id ?? 'n/a'}`,
+        ].join('\n')
+      : 'No fixture linked.',
+    inline: false,
+  });
+
+  embed.addFields({
+    name: 'Players',
+    value:
+      report.players.length > 0
+        ? report.players
+            .map((player) => `${player.discord_username}: local ${player.local_player_id}, sprocket ${player.sprocket_player_id ?? 'n/a'}, team ${player.team_id ?? 'n/a'}`)
+            .join('\n')
+            .slice(0, 1024)
+        : 'No players found.',
+    inline: false,
+  });
+
+  embed.addFields({
+    name: 'Rows',
+    value: `Stats: ${report.stats.reduce((sum, row) => sum + row.stat_rows, 0)} | Eligibility: ${report.eligibility.length} | Elo history: ${report.elo_history.length}`,
+    inline: false,
+  });
+
+  return embed.setTimestamp();
 }
 
 async function handleCancelScrim(interaction: ChatInputCommandInteraction) {

--- a/src/services/elo.service.ts
+++ b/src/services/elo.service.ts
@@ -141,6 +141,49 @@ export class EloService {
         }
     }
 
+    async getPlayerEloSummary(playerId: number, league?: League): Promise<{
+        ratings: EloRating[];
+        history: Array<{
+            scrim_id: number;
+            scrim_uid: string;
+            old_rating: number;
+            new_rating: number;
+            change_amount: number;
+            created_at: Date;
+        }>;
+    }> {
+        const params: unknown[] = [playerId];
+        const leagueFilter = league ? `AND er.league = $${params.push(league)}` : '';
+        const ratingsResult = await db.query<EloRating>(
+            `SELECT * FROM ${this.eloRatingsTable} er WHERE er.player_id = $1 ${leagueFilter} ORDER BY er.league`,
+            params
+        );
+
+        const historyParams: unknown[] = [playerId];
+        const historyLeagueFilter = league ? `AND s.league = $${historyParams.push(league)}` : '';
+        const historyResult = await db.query<{
+            scrim_id: number;
+            scrim_uid: string;
+            old_rating: number;
+            new_rating: number;
+            change_amount: number;
+            created_at: Date;
+        }>(
+            `SELECT eh.scrim_id, s.scrim_uid, eh.old_rating, eh.new_rating, eh.change_amount, eh.created_at
+             FROM ${this.eloHistoryTable} eh
+             JOIN ${this.scrimsTable} s ON s.id = eh.scrim_id
+             WHERE eh.player_id = $1 ${historyLeagueFilter}
+             ORDER BY eh.created_at DESC
+             LIMIT 20`,
+            historyParams
+        );
+
+        return {
+            ratings: ratingsResult.rows,
+            history: historyResult.rows,
+        };
+    }
+
     private async updatePlayerRating(
         client: any,
         playerId: number,
@@ -174,7 +217,8 @@ export class EloService {
         // Insert History
         await client.query(
             `INSERT INTO ${this.eloHistoryTable} (player_id, scrim_id, old_rating, new_rating)
-       VALUES ($1, $2, $3, $4)`,
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT DO NOTHING`,
             [playerId, scrimId, currentRating.rating, newRating]
         );
     }

--- a/src/services/fixture.service.ts
+++ b/src/services/fixture.service.ts
@@ -1,0 +1,203 @@
+import { db } from '../db/index.js';
+import { League } from '../types.js';
+import { logger } from '../utils/logger.js';
+import { sprocketService } from './sprocket.service.js';
+
+export interface FixtureCreateOptions {
+  league: League;
+  homeFranchise: string;
+  awayFranchise: string;
+  scheduleGroupId?: number;
+  week?: number;
+}
+
+export interface FixtureInfo {
+  fixtureId: number;
+  scheduleGroupId: number;
+  homeFranchiseId: number;
+  awayFranchiseId: number;
+  skillGroupId: number;
+  gameModeId: number | null;
+}
+
+interface IdNameRow {
+  id: number;
+  name: string;
+}
+
+interface IdRow {
+  id: number;
+}
+
+export class FixtureService {
+  async getOrCreateTestFixture(
+    client: { query: <T = IdRow>(text: string, params?: unknown[]) => Promise<{ rows: T[] }> },
+    options: FixtureCreateOptions
+  ): Promise<FixtureInfo> {
+    const skillGroupId = await sprocketService.getSkillGroupIdForLeague(options.league);
+    if (!skillGroupId) {
+      throw new Error(`No Trackmania skill group configured for league ${options.league}`);
+    }
+
+    const scheduleGroupId =
+      options.scheduleGroupId ??
+      (await this.getOrCreateTrackmaniaTestScheduleGroup(client, skillGroupId, options.week));
+    const homeFranchiseId = await this.resolveFranchiseId(client, options.homeFranchise);
+    const awayFranchiseId = await this.resolveFranchiseId(client, options.awayFranchise);
+    const gameModeId = await this.getTrackmaniaGameModeId(client);
+
+    const existingResult = await client.query<IdRow>(
+      `
+      SELECT id
+      FROM sprocket.schedule_fixture
+      WHERE "scheduleGroupId" = $1
+        AND "homeFranchiseId" = $2
+        AND "awayFranchiseId" = $3
+        AND "skillGroupId" = $4
+      ORDER BY id DESC
+      LIMIT 1
+      `,
+      [scheduleGroupId, homeFranchiseId, awayFranchiseId, skillGroupId]
+    );
+
+    const fixtureId =
+      existingResult.rows[0]?.id ??
+      (
+        await client.query<IdRow>(
+          `
+          INSERT INTO sprocket.schedule_fixture (
+            "scheduleGroupId",
+            "homeFranchiseId",
+            "awayFranchiseId",
+            "skillGroupId",
+            "gameModeId"
+          )
+          VALUES ($1, $2, $3, $4, $5)
+          RETURNING id
+          `,
+          [scheduleGroupId, homeFranchiseId, awayFranchiseId, skillGroupId, gameModeId]
+        )
+      ).rows[0].id;
+
+    logger.info('Resolved Trackmania fixture', {
+      fixtureId,
+      scheduleGroupId,
+      homeFranchiseId,
+      awayFranchiseId,
+      skillGroupId,
+      gameModeId,
+    });
+
+    return {
+      fixtureId,
+      scheduleGroupId,
+      homeFranchiseId,
+      awayFranchiseId,
+      skillGroupId,
+      gameModeId,
+    };
+  }
+
+  async resolveFixture(
+    client: { query: <T = IdRow>(text: string, params?: unknown[]) => Promise<{ rows: T[] }> },
+    fixtureId: number,
+    league: League
+  ): Promise<FixtureInfo> {
+    const skillGroupId = await sprocketService.getSkillGroupIdForLeague(league);
+    if (!skillGroupId) {
+      throw new Error(`No Trackmania skill group configured for league ${league}`);
+    }
+
+    const result = await client.query<FixtureInfo>(
+      `
+      SELECT
+        id AS "fixtureId",
+        "scheduleGroupId" AS "scheduleGroupId",
+        "homeFranchiseId" AS "homeFranchiseId",
+        "awayFranchiseId" AS "awayFranchiseId",
+        "skillGroupId" AS "skillGroupId",
+        "gameModeId" AS "gameModeId"
+      FROM sprocket.schedule_fixture
+      WHERE id = $1
+        AND "skillGroupId" = $2
+      `,
+      [fixtureId, skillGroupId]
+    );
+
+    const fixture = result.rows[0];
+    if (!fixture) {
+      throw new Error(`Fixture ${fixtureId} was not found for ${league}`);
+    }
+
+    return fixture;
+  }
+
+  private async getOrCreateTrackmaniaTestScheduleGroup(
+    client: { query: <T = IdRow>(text: string, params?: unknown[]) => Promise<{ rows: T[] }> },
+    skillGroupId: number,
+    week?: number
+  ): Promise<number> {
+    const existingResult = await client.query<IdRow>(
+      `
+      SELECT sg.id
+      FROM sprocket.schedule_group sg
+      WHERE sg.name = 'Trackmania Test'
+      ORDER BY sg.id DESC
+      LIMIT 1
+      `
+    );
+
+    if (existingResult.rows[0]?.id) {
+      return existingResult.rows[0].id;
+    }
+
+    const result = await client.query<IdRow>(
+      `
+      INSERT INTO sprocket.schedule_group (name, week, "skillGroupId")
+      VALUES ('Trackmania Test', $1, $2)
+      RETURNING id
+      `,
+      [week ?? 0, skillGroupId]
+    );
+
+    return result.rows[0].id;
+  }
+
+  private async resolveFranchiseId(
+    client: { query: <T = IdNameRow>(text: string, params?: unknown[]) => Promise<{ rows: T[] }> },
+    franchise: string
+  ): Promise<number> {
+    const numericId = Number(franchise);
+    const result = await client.query<IdNameRow>(
+      Number.isInteger(numericId)
+        ? 'SELECT id, name FROM sprocket.franchise WHERE id = $1'
+        : 'SELECT id, name FROM sprocket.franchise WHERE LOWER(name) = LOWER($1) OR LOWER(code) = LOWER($1) ORDER BY id LIMIT 2',
+      [Number.isInteger(numericId) ? numericId : franchise]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error(`Unable to uniquely resolve franchise ${franchise}`);
+    }
+
+    return result.rows[0].id;
+  }
+
+  private async getTrackmaniaGameModeId(
+    client: { query: <T = IdRow>(text: string, params?: unknown[]) => Promise<{ rows: T[] }> }
+  ): Promise<number | null> {
+    const result = await client.query<IdRow>(
+      `
+      SELECT gm.id
+      FROM sprocket.game_mode gm
+      JOIN sprocket.game g ON g.id = gm."gameId"
+      WHERE g.title = 'Trackmania'
+      ORDER BY gm.id
+      LIMIT 1
+      `
+    );
+
+    return result.rows[0]?.id ?? null;
+  }
+}
+
+export const fixtureService = new FixtureService();

--- a/src/services/fixture.service.ts
+++ b/src/services/fixture.service.ts
@@ -1,4 +1,3 @@
-import { db } from '../db/index.js';
 import { League } from '../types.js';
 import { logger } from '../utils/logger.js';
 import { sprocketService } from './sprocket.service.js';

--- a/src/services/identity-backfill.service.ts
+++ b/src/services/identity-backfill.service.ts
@@ -1,0 +1,97 @@
+import { db, tableName } from '../db/index.js';
+import { logger } from '../utils/logger.js';
+
+export interface IdentityBackfillIssue {
+  local_player_id: number;
+  discord_id: string;
+  discord_username: string;
+  reason: 'missing_sprocket_profile' | 'duplicate_sprocket_profiles';
+  sprocket_player_ids: number[];
+}
+
+interface BackfillRow {
+  id: number;
+  discord_id: string;
+  discord_username: string;
+  sprocket_player_id: number | null;
+  member_id: number | null;
+  sprocket_player_ids: number[] | null;
+}
+
+export class IdentityBackfillService {
+  async backfillTrackmaniaPlayerIdentities(): Promise<IdentityBackfillIssue[]> {
+    const playersTable = tableName('players');
+
+    const result = await db.query<BackfillRow>(
+      `
+      WITH profile_matches AS (
+        SELECT
+          lp.id AS local_player_id,
+          ARRAY_AGG(DISTINCT sp.id) FILTER (WHERE sp.id IS NOT NULL) AS sprocket_player_ids,
+          COUNT(DISTINCT sp.id) AS sprocket_profile_count,
+          MAX(sp.id) AS sprocket_player_id,
+          MAX(m.id) AS member_id,
+          COALESCE(
+            ARRAY_AGG(DISTINCT mpa."platformAccountId")
+            FILTER (WHERE mpa."platformAccountId" IS NOT NULL),
+            ARRAY[]::VARCHAR[]
+          ) AS platform_account_ids
+        FROM ${playersTable} lp
+        LEFT JOIN sprocket.user_authentication_account uaa
+          ON uaa."accountType" = 'DISCORD'
+         AND uaa."accountId" = lp.discord_id
+        LEFT JOIN sprocket."user" u ON u.id = uaa."userId"
+        LEFT JOIN sprocket.member m ON m."userId" = u.id
+        LEFT JOIN sprocket.player sp ON sp."memberId" = m.id
+        LEFT JOIN sprocket.game_skill_group gsg ON gsg.id = sp."skillGroupId"
+        LEFT JOIN sprocket.game g ON g.id = gsg."gameId" AND g.title = 'Trackmania'
+        LEFT JOIN sprocket.member_platform_account mpa ON mpa."memberId" = m.id
+        WHERE g.id IS NOT NULL OR uaa."accountId" IS NULL
+        GROUP BY lp.id
+      ), updated AS (
+        UPDATE ${playersTable} lp
+        SET sprocket_player_id = pm.sprocket_player_id,
+            member_id = pm.member_id,
+            platform_account_ids = pm.platform_account_ids,
+            updated_at = NOW()
+        FROM profile_matches pm
+        WHERE lp.id = pm.local_player_id
+          AND pm.sprocket_profile_count = 1
+        RETURNING lp.id
+      )
+      SELECT
+        lp.id,
+        lp.discord_id,
+        lp.discord_username,
+        pm.sprocket_player_id,
+        pm.member_id,
+        COALESCE(pm.sprocket_player_ids, ARRAY[]::INTEGER[]) AS sprocket_player_ids
+      FROM ${playersTable} lp
+      JOIN profile_matches pm ON pm.local_player_id = lp.id
+      WHERE pm.sprocket_profile_count <> 1
+      ORDER BY lp.id
+      `
+    );
+
+    const issues = result.rows.map((row) => ({
+      local_player_id: row.id,
+      discord_id: row.discord_id,
+      discord_username: row.discord_username,
+      reason:
+        (row.sprocket_player_ids || []).length === 0
+          ? 'missing_sprocket_profile'
+          : 'duplicate_sprocket_profiles',
+      sprocket_player_ids: row.sprocket_player_ids || [],
+    })) satisfies IdentityBackfillIssue[];
+
+    if (issues.length > 0) {
+      logger.warn('Trackmania identity backfill completed with issues', { issues });
+    } else {
+      logger.info('Trackmania identity backfill completed successfully');
+    }
+
+    return issues;
+  }
+}
+
+export const identityBackfillService = new IdentityBackfillService();

--- a/src/services/match-audit.service.ts
+++ b/src/services/match-audit.service.ts
@@ -1,0 +1,271 @@
+import { db, tableName } from '../db/index.js';
+import { logger } from '../utils/logger.js';
+
+export interface MatchAuditPlayer {
+  local_player_id: number;
+  discord_id: string;
+  discord_username: string;
+  sprocket_player_id: number | null;
+  member_id: number | null;
+  platform_account_ids: string[];
+  checked_in: boolean;
+  team_id: number | null;
+}
+
+export interface MatchAuditStatsRow {
+  map_id: number | null;
+  map_uid: string | null;
+  map_name: string | null;
+  player_id: number;
+  stat_rows: number;
+}
+
+export interface MatchAuditEligibilityRow {
+  player_id: number;
+  points: number;
+}
+
+export interface MatchAuditEloRow {
+  player_id: number;
+  old_rating: number;
+  new_rating: number;
+  change_amount: number;
+  created_at: Date;
+}
+
+export interface MatchAuditCurrentEloRow {
+  player_id: number;
+  rating: number;
+  wins: number;
+  losses: number;
+  updated_at: Date;
+}
+
+export interface MatchAuditFixture {
+  fixture_id: number | null;
+  home_franchise_id: number | null;
+  home_franchise_name: string | null;
+  away_franchise_id: number | null;
+  away_franchise_name: string | null;
+  league: string | null;
+  game_mode: string | null;
+  schedule_group_id: number | null;
+  schedule_group_name: string | null;
+}
+
+export interface MatchAuditReport {
+  scrim: {
+    id: number;
+    scrim_uid: string;
+    league: string;
+    status: string;
+    match_type: string;
+    winner_team: number | null;
+    elo_processed: boolean;
+    sprocket_match_parent_id: number | null;
+    sprocket_match_id: number | null;
+  };
+  fixture: MatchAuditFixture | null;
+  players: MatchAuditPlayer[];
+  stats: MatchAuditStatsRow[];
+  eligibility: MatchAuditEligibilityRow[];
+  elo_history: MatchAuditEloRow[];
+  current_elo: MatchAuditCurrentEloRow[];
+  checks: {
+    fixture_linked: boolean;
+    stats_present: boolean;
+    eligibility_present: boolean;
+    elo_ready: boolean;
+    elo_processed_once: boolean;
+  };
+}
+
+interface ScrimAuditRow {
+  id: number;
+  scrim_uid: string;
+  league: string;
+  status: string;
+  match_type: string;
+  winner_team: number | null;
+  elo_processed: boolean;
+  sprocket_match_parent_id: number | null;
+  sprocket_match_id: number | null;
+  fixture_id: number | null;
+  home_franchise_id: number | null;
+  home_franchise_name: string | null;
+  away_franchise_id: number | null;
+  away_franchise_name: string | null;
+  fixture_league: string | null;
+  game_mode: string | null;
+  schedule_group_id: number | null;
+  schedule_group_name: string | null;
+}
+
+export class MatchAuditService {
+  async auditByScrimUid(scrimUid: string): Promise<MatchAuditReport | null> {
+    const scrimsTable = tableName('scrims');
+    const scrimPlayersTable = tableName('scrim_players');
+    const playersTable = tableName('players');
+    const matchPlayerStatsTable = tableName('match_player_stats');
+    const mapsTable = tableName('maps');
+    const eloHistoryTable = tableName('elo_history');
+    const eloRatingsTable = tableName('elo_ratings');
+
+    const scrimResult = await db.query<ScrimAuditRow>(
+      `
+      SELECT
+        s.id,
+        s.scrim_uid,
+        s.league,
+        s.status,
+        s.match_type,
+        s.winner_team,
+        s.elo_processed,
+        s.sprocket_match_parent_id,
+        s.sprocket_match_id,
+        mp."fixtureId" AS fixture_id,
+        sf."homeFranchiseId" AS home_franchise_id,
+        hf.name AS home_franchise_name,
+        sf."awayFranchiseId" AS away_franchise_id,
+        af.name AS away_franchise_name,
+        COALESCE(gsgp.description, gsgp.code) AS fixture_league,
+        gm.name AS game_mode,
+        sg.id AS schedule_group_id,
+        sg.name AS schedule_group_name
+      FROM ${scrimsTable} s
+      LEFT JOIN sprocket.match_parent mp ON mp.id = s.sprocket_match_parent_id
+      LEFT JOIN sprocket.schedule_fixture sf ON sf.id = mp."fixtureId"
+      LEFT JOIN sprocket.franchise hf ON hf.id = sf."homeFranchiseId"
+      LEFT JOIN sprocket.franchise af ON af.id = sf."awayFranchiseId"
+      LEFT JOIN sprocket.schedule_group sg ON sg.id = sf."scheduleGroupId"
+      LEFT JOIN sprocket.game_skill_group gsg ON gsg.id = sf."skillGroupId"
+      LEFT JOIN sprocket.game_skill_group_profile gsgp ON gsgp."skillGroupId" = gsg.id
+      LEFT JOIN sprocket.game_mode gm ON gm.id = sf."gameModeId"
+      WHERE s.scrim_uid = $1
+      `,
+      [scrimUid]
+    );
+
+    const scrim = scrimResult.rows[0];
+    if (!scrim) {
+      return null;
+    }
+
+    const playersResult = await db.query<MatchAuditPlayer>(
+      `
+      SELECT
+        p.id AS local_player_id,
+        p.discord_id,
+        p.discord_username,
+        p.sprocket_player_id,
+        p.member_id,
+        COALESCE(p.platform_account_ids, ARRAY[]::VARCHAR[]) AS platform_account_ids,
+        sp.checked_in,
+        MIN(mps.team_id) AS team_id
+      FROM ${scrimPlayersTable} sp
+      JOIN ${playersTable} p ON p.id = sp.player_id
+      LEFT JOIN ${matchPlayerStatsTable} mps
+        ON mps.scrim_id = sp.scrim_id
+       AND mps.player_id = sp.player_id
+      WHERE sp.scrim_id = $1
+      GROUP BY p.id, p.discord_id, p.discord_username, p.sprocket_player_id, p.member_id, p.platform_account_ids, sp.checked_in
+      ORDER BY sp.id
+      `,
+      [scrim.id]
+    );
+
+    const statsResult = await db.query<MatchAuditStatsRow>(
+      `
+      SELECT
+        mps.map_id,
+        m.uid AS map_uid,
+        m.name AS map_name,
+        mps.player_id,
+        COUNT(*)::INTEGER AS stat_rows
+      FROM ${matchPlayerStatsTable} mps
+      LEFT JOIN ${mapsTable} m ON m.id = mps.map_id
+      WHERE mps.scrim_id = $1
+      GROUP BY mps.map_id, m.uid, m.name, mps.player_id
+      ORDER BY mps.map_id NULLS LAST, mps.player_id
+      `,
+      [scrim.id]
+    );
+
+    const eligibilityResult = await db.query<MatchAuditEligibilityRow>(
+      `
+      SELECT "playerId" AS player_id, points
+      FROM sprocket.eligibility_data
+      WHERE "matchParentId" = $1
+      ORDER BY "playerId"
+      `,
+      [scrim.sprocket_match_parent_id]
+    );
+
+    const eloHistoryResult = await db.query<MatchAuditEloRow>(
+      `
+      SELECT player_id, old_rating, new_rating, change_amount, created_at
+      FROM ${eloHistoryTable}
+      WHERE scrim_id = $1
+      ORDER BY player_id
+      `,
+      [scrim.id]
+    );
+
+    const currentEloResult = await db.query<MatchAuditCurrentEloRow>(
+      `
+      SELECT er.player_id, er.rating, er.wins, er.losses, er.updated_at
+      FROM ${eloRatingsTable} er
+      JOIN ${scrimPlayersTable} sp ON sp.player_id = er.player_id
+      WHERE sp.scrim_id = $1
+        AND er.league = $2
+      ORDER BY er.player_id
+      `,
+      [scrim.id, scrim.league]
+    );
+
+    const report: MatchAuditReport = {
+      scrim: {
+        id: scrim.id,
+        scrim_uid: scrim.scrim_uid,
+        league: scrim.league,
+        status: scrim.status,
+        match_type: scrim.match_type,
+        winner_team: scrim.winner_team,
+        elo_processed: scrim.elo_processed,
+        sprocket_match_parent_id: scrim.sprocket_match_parent_id,
+        sprocket_match_id: scrim.sprocket_match_id,
+      },
+      fixture: scrim.fixture_id
+        ? {
+            fixture_id: scrim.fixture_id,
+            home_franchise_id: scrim.home_franchise_id,
+            home_franchise_name: scrim.home_franchise_name,
+            away_franchise_id: scrim.away_franchise_id,
+            away_franchise_name: scrim.away_franchise_name,
+            league: scrim.fixture_league,
+            game_mode: scrim.game_mode,
+            schedule_group_id: scrim.schedule_group_id,
+            schedule_group_name: scrim.schedule_group_name,
+          }
+        : null,
+      players: playersResult.rows,
+      stats: statsResult.rows,
+      eligibility: eligibilityResult.rows,
+      elo_history: eloHistoryResult.rows,
+      current_elo: currentEloResult.rows,
+      checks: {
+        fixture_linked: scrim.fixture_id !== null,
+        stats_present: statsResult.rows.length > 0,
+        eligibility_present: eligibilityResult.rows.length >= playersResult.rows.length,
+        elo_ready: scrim.status === 'completed' && scrim.winner_team !== null,
+        elo_processed_once:
+          !scrim.elo_processed || eloHistoryResult.rows.length === playersResult.rows.length,
+      },
+    };
+
+    logger.info('Trackmania match audit report', { report });
+    return report;
+  }
+}
+
+export const matchAuditService = new MatchAuditService();

--- a/src/services/match-audit.service.ts
+++ b/src/services/match-audit.service.ts
@@ -168,7 +168,7 @@ export class MatchAuditService {
         ON mps.scrim_id = sp.scrim_id
        AND mps.player_id = sp.player_id
       WHERE sp.scrim_id = $1
-      GROUP BY p.id, p.discord_id, p.discord_username, p.sprocket_player_id, p.member_id, p.platform_account_ids, sp.checked_in
+      GROUP BY sp.id, p.id, p.discord_id, p.discord_username, p.sprocket_player_id, p.member_id, p.platform_account_ids, sp.checked_in
       ORDER BY sp.id
       `,
       [scrim.id]

--- a/src/services/match-audit.service.ts
+++ b/src/services/match-audit.service.ts
@@ -259,7 +259,7 @@ export class MatchAuditService {
         eligibility_present: eligibilityResult.rows.length >= playersResult.rows.length,
         elo_ready: scrim.status === 'completed' && scrim.winner_team !== null,
         elo_processed_once:
-          !scrim.elo_processed || eloHistoryResult.rows.length === playersResult.rows.length,
+          scrim.elo_processed === (eloHistoryResult.rows.length === playersResult.rows.length),
       },
     };
 

--- a/src/services/platform-review-fixes.test.ts
+++ b/src/services/platform-review-fixes.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockGetSkillGroupIdForLeague: vi.fn(),
+}));
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    query: mocks.mockQuery,
+  },
+  tableName: (table: string) => `trackmania.${table}`,
+}));
+
+vi.mock('./sprocket.service.js', () => ({
+  sprocketService: {
+    getSkillGroupIdForLeague: mocks.mockGetSkillGroupIdForLeague,
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { FixtureService } from './fixture.service.js';
+import { IdentityBackfillService } from './identity-backfill.service.js';
+import { MatchAuditService } from './match-audit.service.js';
+
+describe('FixtureService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects an existing fixture when the skill group does not match the league', async () => {
+    mocks.mockGetSkillGroupIdForLeague.mockResolvedValue(42);
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    };
+
+    await expect(new FixtureService().resolveFixture(client, 9001, 'Master')).rejects.toThrow(
+      'Fixture 9001 was not found for Master'
+    );
+    expect(client.query).toHaveBeenCalledWith(expect.stringContaining('"skillGroupId" = $2'), [9001, 42]);
+  });
+});
+
+describe('MatchAuditService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a full audit report with tightened Elo consistency checks', async () => {
+    mocks.mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 7,
+            scrim_uid: 'SCRIM-123',
+            league: 'Master',
+            status: 'completed',
+            match_type: 'SCHEDULED',
+            winner_team: 1,
+            elo_processed: true,
+            sprocket_match_parent_id: 70,
+            sprocket_match_id: 71,
+            fixture_id: 100,
+            home_franchise_id: 1,
+            home_franchise_name: 'Flames',
+            away_franchise_id: 2,
+            away_franchise_name: 'Jets',
+            fixture_league: 'Master',
+            game_mode: 'Teams',
+            schedule_group_id: 10,
+            schedule_group_name: 'Trackmania Test',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            local_player_id: 1,
+            discord_id: '1001',
+            discord_username: 'Alpha',
+            sprocket_player_id: 501,
+            member_id: 301,
+            platform_account_ids: ['alpha'],
+            checked_in: true,
+            team_id: 1,
+          },
+          {
+            local_player_id: 2,
+            discord_id: '1002',
+            discord_username: 'Bravo',
+            sprocket_player_id: 502,
+            member_id: 302,
+            platform_account_ids: ['bravo'],
+            checked_in: true,
+            team_id: 2,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ map_id: 11, map_uid: 'map-1', map_name: 'Map One', player_id: 1, stat_rows: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ player_id: 501, points: 10 }, { player_id: 502, points: 8 }] })
+      .mockResolvedValueOnce({ rows: [{ player_id: 1, old_rating: 1000, new_rating: 1016, change_amount: 16, created_at: new Date() }] })
+      .mockResolvedValueOnce({ rows: [{ player_id: 1, rating: 1016, wins: 1, losses: 0, updated_at: new Date() }] });
+
+    const report = await new MatchAuditService().auditByScrimUid('SCRIM-123');
+
+    expect(report?.scrim.scrim_uid).toBe('SCRIM-123');
+    expect(report?.fixture?.fixture_id).toBe(100);
+    expect(report?.players).toHaveLength(2);
+    expect(report?.checks.fixture_linked).toBe(true);
+    expect(report?.checks.stats_present).toBe(true);
+    expect(report?.checks.eligibility_present).toBe(true);
+    expect(report?.checks.elo_ready).toBe(true);
+    expect(report?.checks.elo_processed_once).toBe(false);
+  });
+});
+
+describe('IdentityBackfillService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('classifies missing and duplicate Sprocket profiles', async () => {
+    mocks.mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          discord_id: '1001',
+          discord_username: 'Missing',
+          sprocket_player_id: null,
+          member_id: null,
+          sprocket_player_ids: [],
+        },
+        {
+          id: 2,
+          discord_id: '1002',
+          discord_username: 'Duplicate',
+          sprocket_player_id: 502,
+          member_id: 302,
+          sprocket_player_ids: [502, 503],
+        },
+      ],
+    });
+
+    const issues = await new IdentityBackfillService().backfillTrackmaniaPlayerIdentities();
+
+    expect(issues).toEqual([
+      {
+        local_player_id: 1,
+        discord_id: '1001',
+        discord_username: 'Missing',
+        reason: 'missing_sprocket_profile',
+        sprocket_player_ids: [],
+      },
+      {
+        local_player_id: 2,
+        discord_id: '1002',
+        discord_username: 'Duplicate',
+        reason: 'duplicate_sprocket_profiles',
+        sprocket_player_ids: [502, 503],
+      },
+    ]);
+  });
+});

--- a/src/services/player.service.ts
+++ b/src/services/player.service.ts
@@ -144,19 +144,43 @@ export class PlayerService {
           `UPDATE ${this.playersTable}
            SET discord_username = $2,
                league = $3,
+               sprocket_player_id = $4,
+               member_id = $5,
+               platform_account_ids = $6,
                updated_at = NOW()
            WHERE discord_id = $1
            RETURNING *`,
-          [discordId, discordUsername, league],
+          [
+            discordId,
+            discordUsername,
+            league,
+            profile.sprocket_player_id,
+            profile.member_id,
+            profile.platform_accounts,
+          ],
         );
         return result.rows[0] || existing;
       }
 
       const result = await db.query<Player>(
-        `INSERT INTO ${this.playersTable} (discord_id, discord_username, league)
-         VALUES ($1, $2, $3)
+        `INSERT INTO ${this.playersTable} (
+           discord_id,
+           discord_username,
+           league,
+           sprocket_player_id,
+           member_id,
+           platform_account_ids
+         )
+         VALUES ($1, $2, $3, $4, $5, $6)
          RETURNING *`,
-        [discordId, discordUsername, league],
+        [
+          discordId,
+          discordUsername,
+          league,
+          profile.sprocket_player_id,
+          profile.member_id,
+          profile.platform_accounts,
+        ],
       );
       return result.rows[0] || null;
     } catch (error) {

--- a/src/services/roster.service.test.ts
+++ b/src/services/roster.service.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockGetClient: vi.fn(),
+  mockGetTrackmaniaProfileByDiscordId: vi.fn(),
+  mockGetSkillGroupIdForLeague: vi.fn(),
+}));
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    query: mocks.mockQuery,
+    getClient: mocks.mockGetClient,
+  },
+}));
+
+vi.mock('./sprocket.service.js', () => ({
+  sprocketService: {
+    getTrackmaniaProfileByDiscordId: mocks.mockGetTrackmaniaProfileByDiscordId,
+    getSkillGroupIdForLeague: mocks.mockGetSkillGroupIdForLeague,
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { RosterService } from './roster.service.js';
+
+describe('RosterService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detaches a player from old roster slots before assigning the new slot', async () => {
+    const client = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    mocks.mockGetClient.mockResolvedValue(client);
+    mocks.mockGetTrackmaniaProfileByDiscordId.mockResolvedValue({ sprocket_player_id: 501 });
+    mocks.mockGetSkillGroupIdForLeague.mockResolvedValue(42);
+
+    client.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 200 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 300 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 400 }] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [] });
+    mocks.mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          slot_id: 400,
+          team_id: 200,
+          team_name: 'Flames ML',
+          franchise_id: 20,
+          franchise_name: 'Flames',
+          role_id: 300,
+          role_name: 'Starter',
+          player_id: 501,
+          member_id: 301,
+          discord_id: '1001',
+          discord_username: 'Alpha',
+        },
+      ],
+    });
+
+    const row = await new RosterService().addPlayer('1001', 'Flames', 'Starter', 'Master');
+
+    expect(row.slot_id).toBe(400);
+    expect(client.query).toHaveBeenNthCalledWith(5, 'UPDATE sprocket.roster_slot SET "playerId" = NULL WHERE "playerId" = $1', [501]);
+    expect(client.query).toHaveBeenNthCalledWith(6, 'UPDATE sprocket.roster_slot SET "playerId" = $1 WHERE id = $2', [501, 400]);
+    expect(client.query).toHaveBeenCalledWith('COMMIT');
+    expect(client.release).toHaveBeenCalled();
+  });
+});

--- a/src/services/roster.service.ts
+++ b/src/services/roster.service.ts
@@ -1,0 +1,188 @@
+import { db } from '../db/index.js';
+import { League } from '../types.js';
+import { logger } from '../utils/logger.js';
+import { sprocketService } from './sprocket.service.js';
+
+export interface RosterSlotRow {
+  slot_id: number;
+  team_id: number;
+  team_name: string;
+  franchise_id: number;
+  franchise_name: string;
+  role_id: number;
+  role_name: string;
+  player_id: number | null;
+  member_id: number | null;
+  discord_id: string | null;
+}
+
+interface IdRow {
+  id: number;
+}
+
+export class RosterService {
+  async addPlayer(discordId: string, franchise: string, slot: string, league: League): Promise<RosterSlotRow> {
+    const profile = await sprocketService.getTrackmaniaProfileByDiscordId(discordId);
+    if (!profile) {
+      throw new Error(`No Trackmania Sprocket profile found for Discord ID ${discordId}`);
+    }
+
+    const client = await db.getClient();
+    try {
+      await client.query('BEGIN');
+
+      const teamId = await this.resolveTeamId(client, franchise, league);
+      const roleId = await this.resolveRosterRoleId(client, slot, league);
+      const targetSlot = await this.resolveRosterSlotId(client, teamId, roleId);
+
+      await client.query(
+        'UPDATE sprocket.roster_slot SET "playerId" = NULL WHERE "playerId" = $1',
+        [profile.sprocket_player_id]
+      );
+      await client.query(
+        'UPDATE sprocket.roster_slot SET "playerId" = $1 WHERE id = $2',
+        [profile.sprocket_player_id, targetSlot]
+      );
+
+      await client.query('COMMIT');
+      const rows = await this.showFranchise(franchise, league);
+      const updated = rows.find((row) => row.slot_id === targetSlot);
+      if (!updated) {
+        throw new Error('Roster slot was updated but could not be reloaded');
+      }
+      logger.info('Trackmania roster player added', { discordId, franchise, slot, league, targetSlot });
+      return updated;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      logger.error('Error adding Trackmania roster player', { discordId, franchise, slot, league, error });
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async removePlayer(discordId: string): Promise<number> {
+    const profile = await sprocketService.getTrackmaniaProfileByDiscordId(discordId);
+    if (!profile) {
+      throw new Error(`No Trackmania Sprocket profile found for Discord ID ${discordId}`);
+    }
+
+    const result = await db.query(
+      'UPDATE sprocket.roster_slot SET "playerId" = NULL WHERE "playerId" = $1',
+      [profile.sprocket_player_id]
+    );
+    logger.info('Trackmania roster player removed', { discordId, clearedSlots: result.rowCount ?? 0 });
+    return result.rowCount ?? 0;
+  }
+
+  async showFranchise(franchise: string, league: League): Promise<RosterSlotRow[]> {
+    const skillGroupId = await sprocketService.getSkillGroupIdForLeague(league);
+    if (!skillGroupId) {
+      throw new Error(`No Trackmania skill group configured for league ${league}`);
+    }
+
+    const result = await db.query<RosterSlotRow>(
+      `
+      SELECT
+        rs.id AS slot_id,
+        t.id AS team_id,
+        t.name AS team_name,
+        f.id AS franchise_id,
+        f.name AS franchise_name,
+        rr.id AS role_id,
+        rr.name AS role_name,
+        rs."playerId" AS player_id,
+        m.id AS member_id,
+        uaa."accountId" AS discord_id
+      FROM sprocket.roster_slot rs
+      JOIN sprocket.team t ON t.id = rs."teamId"
+      JOIN sprocket.franchise f ON f.id = t."franchiseId"
+      JOIN sprocket.roster_role rr ON rr.id = rs."roleId"
+      LEFT JOIN sprocket.player p ON p.id = rs."playerId"
+      LEFT JOIN sprocket.member m ON m.id = p."memberId"
+      LEFT JOIN sprocket."user" u ON u.id = m."userId"
+      LEFT JOIN sprocket.user_authentication_account uaa
+        ON uaa."userId" = u.id
+       AND uaa."accountType" = 'DISCORD'
+      WHERE t."skillGroupId" = $1
+        AND (LOWER(f.name) = LOWER($2) OR LOWER(f.code) = LOWER($2) OR f.id::TEXT = $2)
+      ORDER BY rr.name, rs.id
+      `,
+      [skillGroupId, franchise]
+    );
+
+    return result.rows;
+  }
+
+  private async resolveTeamId(client: any, franchise: string, league: League): Promise<number> {
+    const skillGroupId = await sprocketService.getSkillGroupIdForLeague(league);
+    if (!skillGroupId) {
+      throw new Error(`No Trackmania skill group configured for league ${league}`);
+    }
+
+    const result = await client.query<IdRow>(
+      `
+      SELECT t.id
+      FROM sprocket.team t
+      JOIN sprocket.franchise f ON f.id = t."franchiseId"
+      WHERE t."skillGroupId" = $1
+        AND (LOWER(f.name) = LOWER($2) OR LOWER(f.code) = LOWER($2) OR f.id::TEXT = $2)
+      ORDER BY t.id
+      LIMIT 2
+      `,
+      [skillGroupId, franchise]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error(`Unable to uniquely resolve Trackmania team for ${franchise} in ${league}`);
+    }
+
+    return result.rows[0].id;
+  }
+
+  private async resolveRosterRoleId(client: any, slot: string, league: League): Promise<number> {
+    const skillGroupId = await sprocketService.getSkillGroupIdForLeague(league);
+    if (!skillGroupId) {
+      throw new Error(`No Trackmania skill group configured for league ${league}`);
+    }
+
+    const result = await client.query<IdRow>(
+      `
+      SELECT id
+      FROM sprocket.roster_role
+      WHERE "skillGroupId" = $1
+        AND (LOWER(name) = LOWER($2) OR LOWER(code) = LOWER($2) OR id::TEXT = $2)
+      ORDER BY id
+      LIMIT 2
+      `,
+      [skillGroupId, slot]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error(`Unable to uniquely resolve roster role ${slot} for ${league}`);
+    }
+
+    return result.rows[0].id;
+  }
+
+  private async resolveRosterSlotId(client: any, teamId: number, roleId: number): Promise<number> {
+    const result = await client.query<IdRow>(
+      `
+      SELECT id
+      FROM sprocket.roster_slot
+      WHERE "teamId" = $1 AND "roleId" = $2
+      ORDER BY id
+      LIMIT 2
+      `,
+      [teamId, roleId]
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error(`Unable to uniquely resolve roster slot for team ${teamId} and role ${roleId}`);
+    }
+
+    return result.rows[0].id;
+  }
+}
+
+export const rosterService = new RosterService();

--- a/src/services/roster.service.ts
+++ b/src/services/roster.service.ts
@@ -20,6 +20,10 @@ interface IdRow {
   id: number;
 }
 
+type DbClient = {
+  query: <T = IdRow>(text: string, params?: unknown[]) => Promise<{ rows: T[]; rowCount?: number | null }>;
+};
+
 export class RosterService {
   async addPlayer(discordId: string, franchise: string, slot: string, league: League): Promise<RosterSlotRow> {
     const profile = await sprocketService.getTrackmaniaProfileByDiscordId(discordId);
@@ -114,7 +118,7 @@ export class RosterService {
     return result.rows;
   }
 
-  private async resolveTeamId(client: any, franchise: string, league: League): Promise<number> {
+  private async resolveTeamId(client: DbClient, franchise: string, league: League): Promise<number> {
     const skillGroupId = await sprocketService.getSkillGroupIdForLeague(league);
     if (!skillGroupId) {
       throw new Error(`No Trackmania skill group configured for league ${league}`);
@@ -140,7 +144,7 @@ export class RosterService {
     return result.rows[0].id;
   }
 
-  private async resolveRosterRoleId(client: any, slot: string, league: League): Promise<number> {
+  private async resolveRosterRoleId(client: DbClient, slot: string, league: League): Promise<number> {
     const skillGroupId = await sprocketService.getSkillGroupIdForLeague(league);
     if (!skillGroupId) {
       throw new Error(`No Trackmania skill group configured for league ${league}`);
@@ -165,7 +169,7 @@ export class RosterService {
     return result.rows[0].id;
   }
 
-  private async resolveRosterSlotId(client: any, teamId: number, roleId: number): Promise<number> {
+  private async resolveRosterSlotId(client: DbClient, teamId: number, roleId: number): Promise<number> {
     const result = await client.query<IdRow>(
       `
       SELECT id

--- a/src/services/roster.service.ts
+++ b/src/services/roster.service.ts
@@ -14,6 +14,7 @@ export interface RosterSlotRow {
   player_id: number | null;
   member_id: number | null;
   discord_id: string | null;
+  discord_username: string | null;
 }
 
 interface IdRow {
@@ -97,7 +98,8 @@ export class RosterService {
         rr.name AS role_name,
         rs."playerId" AS player_id,
         m.id AS member_id,
-        uaa."accountId" AS discord_id
+        uaa."accountId" AS discord_id,
+        COALESCE(tm_player.discord_username, m.name) AS discord_username
       FROM sprocket.roster_slot rs
       JOIN sprocket.team t ON t.id = rs."teamId"
       JOIN sprocket.franchise f ON f.id = t."franchiseId"
@@ -108,6 +110,7 @@ export class RosterService {
       LEFT JOIN sprocket.user_authentication_account uaa
         ON uaa."userId" = u.id
        AND uaa."accountType" = 'DISCORD'
+      LEFT JOIN trackmania.players tm_player ON tm_player.sprocket_player_id = p.id
       WHERE t."skillGroupId" = $1
         AND (LOWER(f.name) = LOWER($2) OR LOWER(f.code) = LOWER($2) OR f.id::TEXT = $2)
       ORDER BY rr.name, rs.id

--- a/src/services/scrim.service.ts
+++ b/src/services/scrim.service.ts
@@ -5,6 +5,7 @@ import { config } from '../config.js';
 import { randomUUID } from 'crypto';
 import { sprocketService } from './sprocket.service.js';
 import { UrlGenerator } from '../utils/urlGenerator.js';
+import { fixtureService } from './fixture.service.js';
 
 export interface AdminScrimDetail {
   scrim: Scrim;
@@ -24,6 +25,14 @@ interface AdminScrimQueryOptions {
   matchType?: MatchType;
   statuses?: ScrimStatus[];
   limit?: number;
+}
+
+export interface CreateScheduledMatchOptions {
+  fixtureId?: number;
+  homeFranchise?: string;
+  awayFranchise?: string;
+  scheduleGroupId?: number;
+  week?: number;
 }
 
 export class ScrimService {
@@ -113,7 +122,8 @@ export class ScrimService {
    */
   async createScheduledMatch(
     league: League,
-    players: Player[]
+    players: Player[],
+    options: CreateScheduledMatchOptions = {}
   ): Promise<Scrim> {
     if (players.length !== 4) {
       throw new Error('Match must have exactly 4 players');
@@ -125,7 +135,23 @@ export class ScrimService {
 
       // Generate unique scrim ID
       const scrimUid = this.generateScrimId();
-      const sprocketMatch = await sprocketService.createMatchParentAndMatch(client, league, scrimUid);
+      const fixture = options.fixtureId
+        ? await fixtureService.resolveFixture(client, options.fixtureId, league)
+        : options.homeFranchise && options.awayFranchise
+          ? await fixtureService.getOrCreateTestFixture(client, {
+              league,
+              homeFranchise: options.homeFranchise,
+              awayFranchise: options.awayFranchise,
+              scheduleGroupId: options.scheduleGroupId,
+              week: options.week,
+            })
+          : null;
+      const sprocketMatch = await sprocketService.createMatchParentAndMatch(
+        client,
+        league,
+        scrimUid,
+        fixture?.fixtureId
+      );
 
       // Create scrim with SCHEDULED type and ACTIVE status (no check-in needed)
       const scrimResult = await client.query<Scrim>(
@@ -153,6 +179,7 @@ export class ScrimService {
         scrimId: scrim.id,
         scrimUid,
         league,
+        fixtureId: fixture?.fixtureId ?? null,
         playerIds: players.map(p => p.id)
       });
 

--- a/src/services/sprocket.service.ts
+++ b/src/services/sprocket.service.ts
@@ -202,6 +202,7 @@ export class SprocketService {
     client: { query: <T = InsertIdRow>(text: string, params?: unknown[]) => Promise<{ rows: T[] }> },
     league: League,
     submissionId: string,
+    fixtureId?: number,
   ): Promise<{ matchParentId: number; matchId: number }> {
     const skillGroupId = await this.getSkillGroupIdForLeague(league);
     if (!skillGroupId) {
@@ -219,11 +220,11 @@ export class SprocketService {
 
     const matchParentResult = await client.query<InsertIdRow>(
       `
-      INSERT INTO sprocket.match_parent ("scrimMetaId")
-      VALUES ($1)
+      INSERT INTO sprocket.match_parent ("scrimMetaId", "fixtureId")
+      VALUES ($1, $2)
       RETURNING id
       `,
-      [scrimMetaId],
+      [scrimMetaId, fixtureId ?? null],
     );
     const matchParentId = matchParentResult.rows[0]?.id;
 

--- a/src/services/sprocket.service.ts
+++ b/src/services/sprocket.service.ts
@@ -82,6 +82,7 @@ export class SprocketService {
           AND uaa."accountId" = $1
           AND g.title = 'Trackmania'
         GROUP BY p.id, m.id, uaa."accountId", gsg.id, gsgp.code, gsgp.description
+        ORDER BY gsg.id, p.id
         LIMIT 1
         `,
         [discordId],
@@ -126,6 +127,7 @@ export class SprocketService {
         WHERE lookup_mpa."platformAccountId" = $1
           AND g.title = 'Trackmania'
         GROUP BY p.id, m.id, uaa."accountId", gsg.id, gsgp.code, gsgp.description
+        ORDER BY gsg.id, p.id
         LIMIT 1
         `,
         [platformAccountId],
@@ -207,6 +209,21 @@ export class SprocketService {
     const skillGroupId = await this.getSkillGroupIdForLeague(league);
     if (!skillGroupId) {
       throw new Error(`No Trackmania skill group configured for league ${league}`);
+    }
+
+    if (fixtureId !== undefined) {
+      const fixtureResult = await client.query<{ skillGroupId: number }>(
+        `
+        SELECT "skillGroupId" AS "skillGroupId"
+        FROM sprocket.schedule_fixture
+        WHERE id = $1
+        `,
+        [fixtureId],
+      );
+      const fixtureSkillGroupId = fixtureResult.rows[0]?.skillGroupId;
+      if (fixtureSkillGroupId !== skillGroupId) {
+        throw new Error(`Fixture ${fixtureId} does not belong to the Trackmania ${league} skill group`);
+      }
     }
 
     const scrimMetaResult = await client.query<InsertIdRow>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,9 @@ export interface Player {
   discord_id: string;
   discord_username: string;
   league: League;
-  sprocket_player_id: number | null;
-  member_id: number | null;
-  platform_account_ids: string[];
+  sprocket_player_id?: number | null;
+  member_id?: number | null;
+  platform_account_ids?: string[];
   created_at: Date;
   updated_at: Date;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,9 @@ export interface Player {
   discord_id: string;
   discord_username: string;
   league: League;
+  sprocket_player_id: number | null;
+  member_id: number | null;
+  platform_account_ids: string[];
   created_at: Date;
   updated_at: Date;
 }


### PR DESCRIPTION
## Summary
Implement the Trackmania platform integration foundation so scheduled matches, Sprocket identity mapping, parser result ingestion, Elo inspection, audits, and roster administration are ready for LO review and test matches.

## Context
Trackmania needs a reliable bridge between the Discord bot's local Trackmania schema and Sprocket's platform data. This PR implements the plan for linking local players to Sprocket player/member identities, creating fixture-aware scheduled matches, hardening parser result writes, exposing audit/admin tooling, and validating the new flows with tests.

## Changes
- Add local Trackmania-to-Sprocket identity columns, migration, sync persistence, and runtime identity backfill reporting.
- Update parser eligibility writes to use Sprocket player IDs and harden result submission idempotency.
- Add `/admin audit-match`, `/admin elo`, `/admin backfill-identities`, fixture-aware `/admin create-match`, and Trackmania roster admin commands.
- Add fixture creation/resolution, match audit, roster, and identity backfill services.
- Validate optional Sprocket fixture IDs against the Trackmania league skill group before match creation.
- Add Elo history conflict protection and stricter match audit checks for Elo processing consistency.
- Add unit coverage for fixture mismatch rejection, match audit reports, identity backfill issue classification, and roster move behavior.

### Key Implementation Details
- `trackmania.players` now stores nullable `sprocket_player_id`, `member_id`, and `platform_account_ids` so the schema migration can run safely before a full backfill.
- `IdentityBackfillService` can be re-run via `/admin backfill-identities` and reports duplicate/missing Sprocket profile issues without blocking schema migration.
- Scheduled match creation resolves either an existing Sprocket fixture or a persistent `Trackmania Test` fixture, then passes the validated fixture into Sprocket match creation.
- Parser result ingestion uses transactional locking/idempotent inserts and computes the match winner from cumulative map scores before Elo processing.
- Roster commands write to Sprocket roster slots while avoiding pings in roster display output.

## Use Cases
- Admins can create LO test matches attached to a Sprocket fixture or Trackmania test fixture.
- Admins can audit a scrim by UID to verify local stats, Sprocket eligibility rows, fixture linkage, and Elo state.
- Ops can re-run identity backfills and see missing or duplicate Sprocket profile issues.
- Roster admins can add, move, remove, and inspect Trackmania roster slots from Discord.

## Testing
Validation run locally:

```bash
npm run build
npm test -- --run
```

Results:

```text
9 test files passed
42 tests passed
```

Manual review suggestions:

1. Apply migrations through the normal deployment path.
2. Run `/admin backfill-identities` and review any reported missing/duplicate Sprocket profiles.
3. Create a Trackmania test match with `/admin create-match` using home/away franchises.
4. Submit parser results for the created match.
5. Run `/admin audit-match scrim_id:<uid>` and verify fixture, eligibility, stats, and Elo checks.

## Notes
- The repository still has two untracked local markdown files used for implementation/review context; they are intentionally not included in this PR.
- The companion datasets PR adds the public Trackmania SQL queries used for LO verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database schema/migrations and match result/Elo processing paths, including new uniqueness constraints and idempotent writes that could affect production data integrity if misapplied.
> 
> **Overview**
> Establishes **Sprocket identity linkage** for Trackmania players by adding `sprocket_player_id`, `member_id`, and `platform_account_ids` (schema + migration/backfill) and updating player sync to persist these fields.
> 
> Hardens **parser result ingestion** by validating the scrim UID at verification time, computing the match winner from cumulative map scores, and making stats/Elo writes idempotent via new unique constraints (`elo_history` and `match_player_stats`) plus transactional locking/duplicate-detection.
> 
> Adds **ops/admin tooling**: fixture-aware scheduled match creation (existing fixture or auto-created “Trackmania Test” fixture), `/admin audit-match`, `/admin elo`, `/admin backfill-identities`, and `/admin roster` management, backed by new `fixture`, `match-audit`, `identity-backfill`, and `roster` services with accompanying tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf85b274bb3d6aaf993de68be4d52219c32b015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->