### PR TITLE
feat: Add /link-tm command for players to link Trackmania accounts

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,24 @@
+## Summary
+
+Add two commands to help players link their Trackmania accounts so the parser can find them when processing replays:
+
+- `/link-tm` - Self-service command for players to link their own TM account
+- `/admin link-tm` - Admin command for staff to link accounts for others
+
+Both support Steam, Epic, Xbox, and PS4 platforms.
+
+## Why
+
+The parser was failing to save match results because `findTrackmaniaPlayer()` couldn't resolve players - their platform accounts weren't linked in the `sprocket.member_platform_account` table. This caused the entire transaction to rollback, leaving scrims incomplete and no Elo saved.
+
+## Changes
+
+- `src/commands/link-tm.ts` - New self-service command
+- `src/commands/admin.ts` - Added `link-tm` subcommand and handler
+
+## Testing
+
+After deploying:
+1. Run `/link-tm steam <account-id>` to test self-service
+2. Run `/admin link-tm @player steam <account-id>` to test admin command
+3. Submit a replay and verify it saves to `match_player_stats`

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -15,6 +15,7 @@ import { identityBackfillService } from '../services/identity-backfill.service.j
 import { logger } from '../utils/logger.js';
 import { League } from '../types.js';
 import { db, tableName } from '../db/index.js';
+import { parseLinkTmInput, executePlatformLink } from '../services/link-tm.service.js';
 
 export const data = new SlashCommandBuilder()
   .setName('admin')
@@ -574,81 +575,22 @@ async function handleLinkTm(interaction: ChatInputCommandInteraction) {
   const discordId = targetUser.id;
 
   try {
-    // 1. Verify user is registered in trackmania.players
-    const playerResult = await db.query<{ id: number; sprocket_player_id: number }(
-      `SELECT id, sprocket_player_id FROM ${tableName('players')} WHERE discord_id = $1`,
-      [discordId]
-    );
+    const result = await parseLinkTmInput(discordId, platform, accountId);
 
-    if (playerResult.rows.length === 0) {
+    if (result.error) {
       await interaction.editReply({
-        content: `❌ ${targetUser.username} is not registered in the Trackmania system.`,
+        content: `❌ ${targetUser.username}: ${result.message}.`,
       });
       return;
     }
 
-    const player = playerResult.rows[0];
+    const linkResult = await executePlatformLink(result.memberId, result.platformId, result.platformCode, accountId);
 
-    // 2. Get the memberId from sprocket.player
-    const sprocketPlayerResult = await db.query<{ memberId: number }(
-      `SELECT "memberId" FROM sprocket.player WHERE id = $1`,
-      [player.sprocket_player_id]
-    );
+    const message = linkResult.isUpdate
+      ? `✅ Updated ${targetUser.username}'s ${platform} account to \`${accountId}\`.`
+      : `✅ Linked ${targetUser.username}'s ${platform} account (\`${accountId}\`).`;
 
-    if (sprocketPlayerResult.rows.length === 0) {
-      await interaction.editReply({
-        content: `❌ Could not find Sprocket player record for ${targetUser.username}.`,
-      });
-      return;
-    }
-
-    const memberId = sprocketPlayerResult.rows[0].memberId;
-
-    // 3. Get the platform ID
-    const platformResult = await db.query<{ id: number }(
-      `SELECT id FROM sprocket.platform WHERE code = $1`,
-      [platform]
-    );
-
-    if (platformResult.rows.length === 0) {
-      await interaction.editReply({
-        content: `❌ Unknown platform: ${platform}.`,
-      });
-      return;
-    }
-
-    const platformId = platformResult.rows[0].id;
-
-    // 4. Check if already linked
-    const existingLink = await db.query(
-      `SELECT id FROM sprocket.member_platform_account 
-       WHERE "memberId" = $1 AND "platformId" = $2`,
-      [memberId, platformId]
-    );
-
-    if (existingLink.rows.length > 0) {
-      // Update existing
-      await db.query(
-        `UPDATE sprocket.member_platform_account 
-         SET "platformAccountId" = $1, "updatedAt" = NOW()
-         WHERE "memberId" = $2 AND "platformId" = $3`,
-        [accountId, memberId, platformId]
-      );
-      await interaction.editReply({
-        content: `✅ Updated ${targetUser.username}'s ${platform} account to \`${accountId}\`.`,
-      });
-    } else {
-      // Insert new
-      await db.query(
-        `INSERT INTO sprocket.member_platform_account ("platformAccountId", "memberId", "platformId", "createdAt", "updatedAt")
-         VALUES ($1, $2, $3, NOW(), NOW())`,
-        [accountId, memberId, platformId]
-      );
-      await interaction.editReply({
-        content: `✅ Linked ${targetUser.username}'s ${platform} account (\`${accountId}\`).`,
-      });
-    }
-
+    await interaction.editReply({ content: message });
     logger.info(`Admin linked ${targetUser.username} (${discordId}) ${platform} account: ${accountId}`);
 
   } catch (error) {

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -14,6 +14,7 @@ import { rosterService } from '../services/roster.service.js';
 import { identityBackfillService } from '../services/identity-backfill.service.js';
 import { logger } from '../utils/logger.js';
 import { League } from '../types.js';
+import { db, tableName } from '../db/index.js';
 
 export const data = new SlashCommandBuilder()
   .setName('admin')
@@ -91,6 +92,35 @@ export const data = new SlashCommandBuilder()
         option
           .setName('user')
           .setDescription('The user to view dodge history for')
+          .setRequired(true)
+      )
+  )
+  .addSubcommand(subcommand =>
+    subcommand
+      .setName('link-tm')
+      .setDescription("Link a player's Trackmania account")
+      .addUserOption(option =>
+        option
+          .setName('player')
+          .setDescription('The player to link')
+          .setRequired(true)
+      )
+      .addStringOption(option =>
+        option
+          .setName('platform')
+          .setDescription('Gaming platform')
+          .setRequired(true)
+          .addChoices(
+            { name: 'Steam', value: 'STEAM' },
+            { name: 'Epic', value: 'EPIC' },
+            { name: 'Xbox', value: 'XBOX' },
+            { name: 'PS4/PS5', value: 'PS4' }
+          )
+      )
+      .addStringOption(option =>
+        option
+          .setName('account-id')
+          .setDescription("Player's account ID (from Trackmania settings → Account)")
           .setRequired(true)
       )
   )
@@ -312,6 +342,9 @@ export async function execute(interaction: ChatInputCommandInteraction) {
           case 'dodges':
             await handleDodges(interaction);
             break;
+          case 'link-tm':
+            await handleLinkTm(interaction);
+            break;
           case 'create-match':
             await handleCreateMatch(interaction);
             break;
@@ -529,6 +562,101 @@ async function handleDodges(interaction: ChatInputCommandInteraction) {
   embed.setTimestamp();
 
   await interaction.reply({ embeds: [embed], ephemeral: true });
+}
+
+async function handleLinkTm(interaction: ChatInputCommandInteraction) {
+  await interaction.deferReply({ ephemeral: true });
+
+  const targetUser = interaction.options.getUser('player', true);
+  const platform = interaction.options.getString('platform', true);
+  const accountId = interaction.options.getString('account-id', true).trim();
+
+  const discordId = targetUser.id;
+
+  try {
+    // 1. Verify user is registered in trackmania.players
+    const playerResult = await db.query<{ id: number; sprocket_player_id: number }(
+      `SELECT id, sprocket_player_id FROM ${tableName('players')} WHERE discord_id = $1`,
+      [discordId]
+    );
+
+    if (playerResult.rows.length === 0) {
+      await interaction.editReply({
+        content: `❌ ${targetUser.username} is not registered in the Trackmania system.`,
+      });
+      return;
+    }
+
+    const player = playerResult.rows[0];
+
+    // 2. Get the memberId from sprocket.player
+    const sprocketPlayerResult = await db.query<{ memberId: number }(
+      `SELECT "memberId" FROM sprocket.player WHERE id = $1`,
+      [player.sprocket_player_id]
+    );
+
+    if (sprocketPlayerResult.rows.length === 0) {
+      await interaction.editReply({
+        content: `❌ Could not find Sprocket player record for ${targetUser.username}.`,
+      });
+      return;
+    }
+
+    const memberId = sprocketPlayerResult.rows[0].memberId;
+
+    // 3. Get the platform ID
+    const platformResult = await db.query<{ id: number }(
+      `SELECT id FROM sprocket.platform WHERE code = $1`,
+      [platform]
+    );
+
+    if (platformResult.rows.length === 0) {
+      await interaction.editReply({
+        content: `❌ Unknown platform: ${platform}.`,
+      });
+      return;
+    }
+
+    const platformId = platformResult.rows[0].id;
+
+    // 4. Check if already linked
+    const existingLink = await db.query(
+      `SELECT id FROM sprocket.member_platform_account 
+       WHERE "memberId" = $1 AND "platformId" = $2`,
+      [memberId, platformId]
+    );
+
+    if (existingLink.rows.length > 0) {
+      // Update existing
+      await db.query(
+        `UPDATE sprocket.member_platform_account 
+         SET "platformAccountId" = $1, "updatedAt" = NOW()
+         WHERE "memberId" = $2 AND "platformId" = $3`,
+        [accountId, memberId, platformId]
+      );
+      await interaction.editReply({
+        content: `✅ Updated ${targetUser.username}'s ${platform} account to \`${accountId}\`.`,
+      });
+    } else {
+      // Insert new
+      await db.query(
+        `INSERT INTO sprocket.member_platform_account ("platformAccountId", "memberId", "platformId", "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, NOW(), NOW())`,
+        [accountId, memberId, platformId]
+      );
+      await interaction.editReply({
+        content: `✅ Linked ${targetUser.username}'s ${platform} account (\`${accountId}\`).`,
+      });
+    }
+
+    logger.info(`Admin linked ${targetUser.username} (${discordId}) ${platform} account: ${accountId}`);
+
+  } catch (error) {
+    logger.error('Error in /admin link-tm:', error);
+    await interaction.editReply({
+      content: '❌ An error occurred. Please try again or contact a developer.',
+    });
+  }
 }
 
 async function handleRosterCommand(

--- a/src/commands/link-tm.ts
+++ b/src/commands/link-tm.ts
@@ -2,7 +2,7 @@ import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
 } from 'discord.js';
-import { db, tableName } from '../db/index.js';
+import { parseLinkTmInput, executePlatformLink } from '../services/link-tm.service.js';
 import { logger } from '../utils/logger.js';
 
 export const data = new SlashCommandBuilder()
@@ -33,86 +33,23 @@ export async function execute(interaction: ChatInputCommandInteraction) {
   const accountId = interaction.options.getString('account-id')!.trim();
 
   try {
-    // 1. Verify user is registered in trackmania.players
-    const playerResult = await db.query<{ id: number; sprocket_player_id: number }>(
-      `SELECT id, sprocket_player_id FROM ${tableName('players')} WHERE discord_id = $1`,
-      [discordId]
-    );
+    const result = await parseLinkTmInput(discordId, platform, accountId);
 
-    if (playerResult.rows.length === 0) {
+    if (result.error) {
       await interaction.reply({
-        content: `❌ You are not registered in the Trackmania system.\nPlease register on the Sprocket website first, then contact an admin to be added to the bot.`,
+        content: `❌ ${result.message}.\nPlease register on the Sprocket website first, then contact an admin to be added to the bot.`,
         ephemeral: true,
       });
       return;
     }
 
-    const player = playerResult.rows[0];
+    const linkResult = await executePlatformLink(result.memberId, result.platformId, result.platformCode, accountId);
 
-    // 2. Get the memberId from sprocket.player
-    const sprocketPlayerResult = await db.query<{ memberId: number }>(
-      `SELECT "memberId" FROM sprocket.player WHERE id = $1`,
-      [player.sprocket_player_id]
-    );
+    const message = linkResult.isUpdate
+      ? `✅ Updated your ${platform} account ID to \`${accountId}\`. You can now submit replays!`
+      : `✅ Linked your ${platform} account (\`${accountId}\`). You can now submit replays!`;
 
-    if (sprocketPlayerResult.rows.length === 0) {
-      await interaction.reply({
-        content: `❌ Could not find your Sprocket player record. Please contact an admin.`,
-        ephemeral: true,
-      });
-      return;
-    }
-
-    const memberId = sprocketPlayerResult.rows[0].memberId;
-
-    // 3. Get the platform ID
-    const platformResult = await db.query<{ id: number }>(
-      `SELECT id FROM sprocket.platform WHERE code = $1`,
-      [platform]
-    );
-
-    if (platformResult.rows.length === 0) {
-      await interaction.reply({
-        content: `❌ Unknown platform: ${platform}. Please contact an admin.`,
-        ephemeral: true,
-      });
-      return;
-    }
-
-    const platformId = platformResult.rows[0].id;
-
-    // 4. Check if already linked
-    const existingLink = await db.query(
-      `SELECT id FROM sprocket.member_platform_account 
-       WHERE "memberId" = $1 AND "platformId" = $2`,
-      [memberId, platformId]
-    );
-
-    if (existingLink.rows.length > 0) {
-      // Update existing
-      await db.query(
-        `UPDATE sprocket.member_platform_account 
-         SET "platformAccountId" = $1, "updatedAt" = NOW()
-         WHERE "memberId" = $2 AND "platformId" = $3`,
-        [accountId, memberId, platformId]
-      );
-      await interaction.reply({
-        content: `✅ Updated your ${platform} account ID from \`${accountId}\`. You can now submit replays!`,
-        ephemeral: true,
-      });
-    } else {
-      // Insert new
-      await db.query(
-        `INSERT INTO sprocket.member_platform_account ("platformAccountId", "memberId", "platformId", "createdAt", "updatedAt")
-         VALUES ($1, $2, $3, NOW(), NOW())`,
-        [accountId, memberId, platformId]
-      );
-      await interaction.reply({
-        content: `✅ Linked your ${platform} account (\`${accountId}\`). You can now submit replays!`,
-        ephemeral: true,
-      });
-    }
-
+    await interaction.reply({ content: message, ephemeral: true });
     logger.info(`User ${discordId} linked ${platform} account: ${accountId}`);
 
   } catch (error) {

--- a/src/commands/link-tm.ts
+++ b/src/commands/link-tm.ts
@@ -1,0 +1,125 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+} from 'discord.js';
+import { db, tableName } from '../db/index.js';
+import { logger } from '../utils/logger.js';
+
+export const data = new SlashCommandBuilder()
+  .setName('link-tm')
+  .setDescription('Link your Trackmania account to play scrims')
+  .addStringOption((option) =>
+    option
+      .setName('platform')
+      .setDescription('Your gaming platform')
+      .setRequired(true)
+      .addChoices(
+        { name: 'Steam', value: 'STEAM' },
+        { name: 'Epic', value: 'EPIC' },
+        { name: 'Xbox', value: 'XBOX' },
+        { name: 'PS4/PS5', value: 'PS4' }
+      )
+  )
+  .addStringOption((option) =>
+    option
+      .setName('account-id')
+      .setDescription('Your account ID (found in Trackmania settings → Account)')
+      .setRequired(true)
+  );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const discordId = interaction.user.id;
+  const platform = interaction.options.getString('platform')!;
+  const accountId = interaction.options.getString('account-id')!.trim();
+
+  try {
+    // 1. Verify user is registered in trackmania.players
+    const playerResult = await db.query<{ id: number; sprocket_player_id: number }>(
+      `SELECT id, sprocket_player_id FROM ${tableName('players')} WHERE discord_id = $1`,
+      [discordId]
+    );
+
+    if (playerResult.rows.length === 0) {
+      await interaction.reply({
+        content: `❌ You are not registered in the Trackmania system.\nPlease register on the Sprocket website first, then contact an admin to be added to the bot.`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const player = playerResult.rows[0];
+
+    // 2. Get the memberId from sprocket.player
+    const sprocketPlayerResult = await db.query<{ memberId: number }>(
+      `SELECT "memberId" FROM sprocket.player WHERE id = $1`,
+      [player.sprocket_player_id]
+    );
+
+    if (sprocketPlayerResult.rows.length === 0) {
+      await interaction.reply({
+        content: `❌ Could not find your Sprocket player record. Please contact an admin.`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const memberId = sprocketPlayerResult.rows[0].memberId;
+
+    // 3. Get the platform ID
+    const platformResult = await db.query<{ id: number }>(
+      `SELECT id FROM sprocket.platform WHERE code = $1`,
+      [platform]
+    );
+
+    if (platformResult.rows.length === 0) {
+      await interaction.reply({
+        content: `❌ Unknown platform: ${platform}. Please contact an admin.`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const platformId = platformResult.rows[0].id;
+
+    // 4. Check if already linked
+    const existingLink = await db.query(
+      `SELECT id FROM sprocket.member_platform_account 
+       WHERE "memberId" = $1 AND "platformId" = $2`,
+      [memberId, platformId]
+    );
+
+    if (existingLink.rows.length > 0) {
+      // Update existing
+      await db.query(
+        `UPDATE sprocket.member_platform_account 
+         SET "platformAccountId" = $1, "updatedAt" = NOW()
+         WHERE "memberId" = $2 AND "platformId" = $3`,
+        [accountId, memberId, platformId]
+      );
+      await interaction.reply({
+        content: `✅ Updated your ${platform} account ID from \`${accountId}\`. You can now submit replays!`,
+        ephemeral: true,
+      });
+    } else {
+      // Insert new
+      await db.query(
+        `INSERT INTO sprocket.member_platform_account ("platformAccountId", "memberId", "platformId", "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, NOW(), NOW())`,
+        [accountId, memberId, platformId]
+      );
+      await interaction.reply({
+        content: `✅ Linked your ${platform} account (\`${accountId}\`). You can now submit replays!`,
+        ephemeral: true,
+      });
+    }
+
+    logger.info(`User ${discordId} linked ${platform} account: ${accountId}`);
+
+  } catch (error) {
+    logger.error('Error in /link-tm command:', error);
+    await interaction.reply({
+      content: '❌ An error occurred while linking your account. Please contact an admin.',
+      ephemeral: true,
+    });
+  }
+}

--- a/src/services/link-tm.service.ts
+++ b/src/services/link-tm.service.ts
@@ -1,0 +1,103 @@
+import { db, tableName } from '../db/index.js';
+
+export interface LinkedPlatformContext {
+  memberId: number;
+  platformId: number;
+  platformCode: string;
+}
+
+export interface LinkTmError {
+  error: true;
+  message: string;
+}
+
+export type LinkTmResult = LinkedPlatformContext | LinkTmError;
+
+/**
+ * Parses link-tm input into a validated context ready for mutation.
+ * Does NOT validate - returns a type that guarantees the linking mutation will work.
+ * (i.e., all IDs are valid and point to existing records)
+ */
+export async function parseLinkTmInput(
+  discordId: string,
+  platform: string,
+  accountId: string
+): Promise<LinkTmResult> {
+  // 1. Verify user is registered in trackmania.players
+  const playerResult = await db.query<{ id: number; sprocket_player_id: number }>(
+    `SELECT id, sprocket_player_id FROM ${tableName('players')} WHERE discord_id = $1`,
+    [discordId]
+  );
+
+  if (playerResult.rows.length === 0) {
+    return { error: true, message: 'Not registered in Trackmania system' };
+  }
+
+  const player = playerResult.rows[0];
+
+  // 2. Get the memberId from sprocket.player
+  const sprocketPlayerResult = await db.query<{ memberId: number }>(
+    `SELECT "memberId" FROM sprocket.player WHERE id = $1`,
+    [player.sprocket_player_id]
+  );
+
+  if (sprocketPlayerResult.rows.length === 0) {
+    return { error: true, message: 'Could not find Sprocket player record' };
+  }
+
+  const memberId = sprocketPlayerResult.rows[0].memberId;
+
+  // 3. Get the platform ID
+  const platformResult = await db.query<{ id: number }>(
+    `SELECT id FROM sprocket.platform WHERE code = $1`,
+    [platform]
+  );
+
+  if (platformResult.rows.length === 0) {
+    return { error: true, message: `Unknown platform: ${platform}` };
+  }
+
+  const platformId = platformResult.rows[0].id;
+
+  return {
+    memberId,
+    platformId,
+    platformCode: platform,
+  };
+}
+
+/**
+ * Performs the actual link upsert. Call after parseLinkTmInput succeeded.
+ */
+export async function executePlatformLink(
+  memberId: number,
+  platformId: number,
+  platformCode: string,
+  accountId: string
+): Promise<{ isUpdate: boolean }> {
+  // Check if already linked
+  const existingLink = await db.query(
+    `SELECT id FROM sprocket.member_platform_account 
+     WHERE "memberId" = $1 AND "platformId" = $2`,
+    [memberId, platformId]
+  );
+
+  if (existingLink.rows.length > 0) {
+    // Update existing
+    await db.query(
+      `UPDATE sprocket.member_platform_account 
+       SET "platformAccountId" = $1, "updatedAt" = NOW()
+       WHERE "memberId" = $2 AND "platformId" = $3`,
+      [accountId, memberId, platformId]
+    );
+    return { isUpdate: true };
+  } else {
+    // Insert new
+    await db.query(
+      `INSERT INTO sprocket.member_platform_account ("platformAccountId", "memberId", "platformId", "createdAt", "updatedAt")
+       VALUES ($1, $2, $3, NOW(), NOW())`,
+      [accountId, memberId, platformId]
+    );
+    return { isUpdate: false };
+  }
+}


### PR DESCRIPTION
## Summary

Add two commands to help players link their Trackmania accounts so the parser can find them when processing replays:

- `/link-tm` - Self-service command for players to link their own TM account
- `/admin link-tm` - Admin command for staff to link accounts for others

Both support Steam, Epic, Xbox, and PS4 platforms.

## Why

The parser was failing to save match results because `findTrackmaniaPlayer()` couldn't resolve players - their platform accounts weren't linked in the `sprocket.member_platform_account` table. This caused the entire transaction to rollback, leaving scrims incomplete and no Elo saved.

## Changes

- `src/commands/link-tm.ts` - New self-service command
- `src/commands/admin.ts` - Added `link-tm` subcommand and handler

## Testing

After deploying:
1. Run `/link-tm steam <account-id>` to test self-service
2. Run `/admin link-tm @player steam <account-id>` to test admin command
3. Submit a replay and verify it saves to `match_player_stats`