### PR TITLE
fix: resolve TypeScript build errors after merge

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -14,7 +14,6 @@ import { rosterService } from '../services/roster.service.js';
 import { identityBackfillService } from '../services/identity-backfill.service.js';
 import { logger } from '../utils/logger.js';
 import { League } from '../types.js';
-import { db, tableName } from '../db/index.js';
 import { parseLinkTmInput, executePlatformLink } from '../services/link-tm.service.js';
 
 export const data = new SlashCommandBuilder()
@@ -577,14 +576,15 @@ async function handleLinkTm(interaction: ChatInputCommandInteraction) {
   try {
     const result = await parseLinkTmInput(discordId, platform, accountId);
 
-    if (result.error) {
+    if ('error' in result && result.error) {
       await interaction.editReply({
         content: `❌ ${targetUser.username}: ${result.message}.`,
       });
       return;
     }
 
-    const linkResult = await executePlatformLink(result.memberId, result.platformId, result.platformCode, accountId);
+    const success = result as { memberId: number; platformId: number; platformCode: string };
+    const linkResult = await executePlatformLink(success.memberId, success.platformId, success.platformCode, accountId);
 
     const message = linkResult.isUpdate
       ? `✅ Updated ${targetUser.username}'s ${platform} account to \`${accountId}\`.`

--- a/src/commands/link-tm.ts
+++ b/src/commands/link-tm.ts
@@ -35,7 +35,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
   try {
     const result = await parseLinkTmInput(discordId, platform, accountId);
 
-    if (result.error) {
+    if ('error' in result && result.error) {
       await interaction.reply({
         content: `❌ ${result.message}.\nPlease register on the Sprocket website first, then contact an admin to be added to the bot.`,
         ephemeral: true,
@@ -43,7 +43,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
       return;
     }
 
-    const linkResult = await executePlatformLink(result.memberId, result.platformId, result.platformCode, accountId);
+    const success = result as { memberId: number; platformId: number; platformCode: string };
+    const linkResult = await executePlatformLink(success.memberId, success.platformId, success.platformCode, accountId);
 
     const message = linkResult.isUpdate
       ? `✅ Updated your ${platform} account ID to \`${accountId}\`. You can now submit replays!`

--- a/src/services/link-tm.service.ts
+++ b/src/services/link-tm.service.ts
@@ -4,6 +4,7 @@ export interface LinkedPlatformContext {
   memberId: number;
   platformId: number;
   platformCode: string;
+  error?: never;
 }
 
 export interface LinkTmError {
@@ -21,7 +22,7 @@ export type LinkTmResult = LinkedPlatformContext | LinkTmError;
 export async function parseLinkTmInput(
   discordId: string,
   platform: string,
-  accountId: string
+  _accountId: string
 ): Promise<LinkTmResult> {
   // 1. Verify user is registered in trackmania.players
   const playerResult = await db.query<{ id: number; sprocket_player_id: number }>(
@@ -72,7 +73,7 @@ export async function parseLinkTmInput(
 export async function executePlatformLink(
   memberId: number,
   platformId: number,
-  platformCode: string,
+  _platformCode: string,
   accountId: string
 ): Promise<{ isUpdate: boolean }> {
   // Check if already linked


### PR DESCRIPTION
## Summary

Fixes TypeScript build errors that broke the build after PR #9 was merged.

## Changes

- Remove unused `db, tableName` import in admin.ts
- Fix type narrowing for `LinkTmResult` union - use `'error' in result` check instead of direct property access
- Prefix unused parameters with underscore in link-tm.service.ts to satisfy TS6133

## Testing

`npm run build` now passes.